### PR TITLE
secured Adults count in EditForm, Got Print/Details to list donations

### DIFF
--- a/LivingMessiah/Features/Sukkot/Data/DonationQuery.cs
+++ b/LivingMessiah/Features/Sukkot/Data/DonationQuery.cs
@@ -1,0 +1,7 @@
+﻿namespace LivingMessiah.Features.Sukkot.Data;
+
+public record DonationQuery(decimal Amount,	string? ReferenceId,	DateTime CreateDate);
+
+/*
+	int RegistrationId, string? Notes,	string? Email,	string? CreatedBy,
+ */

--- a/LivingMessiah/Features/Sukkot/Data/RegistrationQuery.cs
+++ b/LivingMessiah/Features/Sukkot/Data/RegistrationQuery.cs
@@ -1,9 +1,8 @@
-﻿
-using LivingMessiah.Features.Sukkot.Enums;
+﻿using LivingMessiah.Features.Sukkot.Enums;
 
-namespace LivingMessiah.Features.Sukkot.Domain;
+namespace LivingMessiah.Features.Sukkot.Data;
 
-public class vwRegistration
+public class RegistrationQuery
 {
 	public int Id { get; set; }
 	public string? FamilyName { get; set; }
@@ -15,16 +14,13 @@ public class vwRegistration
 	public int Adults { get; set; }
 	public int ChildBig { get; set; }
 	public int ChildSmall { get; set; }
-	public int AttendanceTotal { get; set; }
+	public int FeeEnumValue { get; set; }
 	public int StepId { get; set; }
 	public string? StepName => Step.FromValue(StepId).Name;
-	public int StepValue => Step.FromValue(StepId);
-	public decimal RegistrationFeeAdjusted { get; set; } // Deprecate, used only by 
 	public string? Notes { get; set; }
 	public int AttendanceBitwise { get; set; }
 	public DateTime[]? AttendanceDateList { get; set; }
 	public DateTime[]? AttendanceDateList2ndMonth { get; set; }
-	public string? PayWithCheckMessage { get; set; }
 	public string? HouseRulesAgreementDate { get; set; }
 	public string FullName(bool includeOthers)
 	{
@@ -34,4 +30,6 @@ public class vwRegistration
 		if (includeOthers) { s += " and " + OtherNames; }
 		return s;
 	}
+
+	public DonationQuery? DonationQuery  { get; set; }
 }

--- a/LivingMessiah/Features/Sukkot/Domain/Donation.cs
+++ b/LivingMessiah/Features/Sukkot/Domain/Donation.cs
@@ -2,12 +2,12 @@ namespace LivingMessiah.Features.Sukkot.Domain;
 
 public class Donation
 {
-	public int RegistrationId { get; set; }
+	//public int RegistrationId { get; set; }
 	public int Detail { get; set; }
 	public decimal Amount { get; set; }
-	public string? Notes { get; set; }
-	public string? Email { get; set; } // DonorEmail
+	//public string? Notes { get; set; }
+	//public string? Email { get; set; } // DonorEmail
 	public string? ReferenceId { get; set; } // StripePaymentIntentId { get; set; }
-	public string? CreatedBy { get; set; }
+	//public string? CreatedBy { get; set; }
 	public DateTime CreateDate { get; set; }
 }

--- a/LivingMessiah/Features/Sukkot/Enums/Step.cs
+++ b/LivingMessiah/Features/Sukkot/Enums/Step.cs
@@ -31,7 +31,7 @@ public abstract class Step : SmartEnum<Step>
 	public abstract string Icon { get; }
 	public abstract string CardHeaderCSS { get; }
 	public abstract string CardBodyCSS { get; }
-	public abstract bool EnableRegistrationToggleButton { get; }
+	public abstract bool RegistrationExists { get; }
 
 	#endregion
 
@@ -45,7 +45,7 @@ public abstract class Step : SmartEnum<Step>
 		public override string Icon => "far fa-handshake"; 
 		public override string CardHeaderCSS => "bg-success-subtle";  
 		public override string CardBodyCSS => "bg-success-subtle";
-		public override bool EnableRegistrationToggleButton => false;
+		public override bool RegistrationExists => false;
 	}
 
 	private sealed class RegistrationSE : Step
@@ -56,7 +56,7 @@ public abstract class Step : SmartEnum<Step>
 		public override string Icon => "far fa-keyboard";
 		public override string CardHeaderCSS => "bg-warning-subtle";
 		public override string CardBodyCSS => "bg-warning-subtle";
-		public override bool EnableRegistrationToggleButton => false;
+		public override bool RegistrationExists => false;
 	}
 
 	private sealed class PaymentSE : Step
@@ -67,7 +67,7 @@ public abstract class Step : SmartEnum<Step>
 		public override string Icon => "fas fa-dollar-sign";   
 		public override string CardHeaderCSS => "bg-danger-subtle";
 		public override string CardBodyCSS => "bg-danger-subtle";
-		public override bool EnableRegistrationToggleButton => true;
+		public override bool RegistrationExists => true;
 	}
 
 	private sealed class CompleteSE : Step
@@ -78,7 +78,7 @@ public abstract class Step : SmartEnum<Step>
 		public override string Icon => "fas fa-flag-checkered"; 
 		public override string CardHeaderCSS => "bg-info-subtle";
 		public override string CardBodyCSS => "bg-info-subtle";
-		public override bool EnableRegistrationToggleButton => true;
+		public override bool RegistrationExists => true;
 	}
 	#endregion
 

--- a/LivingMessiah/Features/Sukkot/NormalUser/EntryForm.razor
+++ b/LivingMessiah/Features/Sukkot/NormalUser/EntryForm.razor
@@ -187,14 +187,18 @@
     </fieldset>
 
     <fieldset class="mt-3">
-      <legend class="text-primary">People Count</legend>
+      <legend class="text-primary">People Count <small class="text-black-50">Step: @(CurrentStep?.Name ?? "???")</small></legend>
 
       <div class="row mt-n2">
         <div class="col-sm-4">
 
           <div class="form-floating mb-3">
 
-            <InputNumber id="adults" class="form-control" @bind-Value="VM.Adults" placeholder="Adult Count" />
+            <InputNumber id="adults"
+                         class="form-control"
+                         @bind-Value="VM.Adults"
+                         placeholder="Adult Count"
+                         disabled="@(CurrentStep?.Value == Step.Complete.Value)" />
             <label for="adults" class="form-label">Adults</label>
             <ValidationMessage For="@(() => VM.Adults)" />
 
@@ -248,8 +252,9 @@
 @code {
   [Parameter, EditorRequired] public int? Id { get; set; }
   [Parameter, EditorRequired] public string? Email { get; set; }
-  [Parameter] public EventCallback<Step> OnActionCompleted { get; set; } //
-  [Parameter] public EventCallback OnUpdateCompleted { get; set; }
+  [Parameter, EditorRequired] public Step? CurrentStep { get; set; }
+  [Parameter] public EventCallback<StepAndRegFee> OnAddCompleted { get; set; }
+  [Parameter] public EventCallback<int> OnUpdateCompleted { get; set; }
 
   bool TurnSpinnerOff = false;
 
@@ -277,7 +282,7 @@
       }
       else
       {
-        AddOrEditState = new EntryFormAddOrEditRecord(IsAdd: false, "Edit - Registration", $"{Email} - #{VM!.Id}", "Update");
+        AddOrEditState = new EntryFormAddOrEditRecord(IsAdd: false, "Edit - Registration", $"{Email}", "Update");
         VM = await GetById(Id2);
       }
     }
@@ -316,7 +321,6 @@
 
   protected async Task SubmitValidForm()
   {
-
     Logger!.LogDebug("{Method}, Action: {Action} Id2:{id}", nameof(SubmitValidForm), Id2 == 0 ? "Add" : "Update", Id2);
     try
     {
@@ -336,7 +340,7 @@
         {
           Logger!.LogInformation("{Method} Registration created! Id2:{id}", nameof(SubmitValidForm), Id2);
           Toast!.ShowInfo($"Registration Added!");
-          await OnActionCompleted.InvokeAsync(Step.Payment);
+          await OnAddCompleted.InvokeAsync(new StepAndRegFee(Step.Payment, RegistrationFeeHelper.AdultsToRegistrationFee(VM.Adults)));
         }
       }
       else
@@ -344,7 +348,7 @@
         var (rowsAffected, sprocReturnValue, returnMsg) = await db!.Update(DTO_From_VM_To_DB(VM!));
         Logger!.LogInformation("{Method}; Registration updated!", nameof(SubmitValidForm));
         Toast!.ShowInfo($"Registration updated!");
-        await OnUpdateCompleted.InvokeAsync();
+        await OnUpdateCompleted.InvokeAsync(VM!.Adults);
       }
     }
     catch (Exception ex)
@@ -376,5 +380,5 @@
     };
     return poco;
   }
-
+  
 }

--- a/LivingMessiah/Features/Sukkot/NormalUser/StepAndRegFee.cs
+++ b/LivingMessiah/Features/Sukkot/NormalUser/StepAndRegFee.cs
@@ -1,0 +1,6 @@
+﻿using LivingMessiah.Features.Sukkot.Enums;
+
+namespace LivingMessiah.Features.Sukkot.NormalUser;
+
+public record StepAndRegFee(Step Step, RegistrationFee RegistrationFee);
+

--- a/LivingMessiah/Features/Sukkot/NormalUser/Toggle.razor
+++ b/LivingMessiah/Features/Sukkot/NormalUser/Toggle.razor
@@ -53,7 +53,7 @@
 	<div class="card mt-1 mb-3">
 		<div class="card-body bg-light">
 			@* This can only occurs if during Update/Edit *@
-			<EntryForm Email="@Email" Id="@Id" OnUpdateCompleted="ReturnUpdateCompleted" />
+			<EntryForm Email="@Email" Id="@Id" CurrentStep=CurrentStep OnUpdateCompleted="ReturnUpdateCompleted" />
 		</div>
 	</div>
 }
@@ -61,6 +61,7 @@
 @code {
 	[Parameter, EditorRequired] public int? Id { get; set; }
 	[Parameter, EditorRequired] public string? Email { get; set; }
+	[Parameter, EditorRequired] public Step? CurrentStep { get; set; }
 
 	public bool IsCollapsed { get; set; } = true;
 	protected void ToggleButtonClick(bool isCollapsed)

--- a/LivingMessiah/Features/Sukkot/NormalUser/UpdateRegistrationToggle.razor
+++ b/LivingMessiah/Features/Sukkot/NormalUser/UpdateRegistrationToggle.razor
@@ -1,0 +1,51 @@
+﻿@using LivingMessiah.Features.Sukkot.Enums
+
+@inject ILogger<UpdateRegistrationToggle>? Logger
+
+@* <div class="d-flex justify-content-end"> </div> *@
+  @if (IsCollapsed)
+  {
+    <button @onclick="@(e => ButtonClick(IsCollapsed))"
+            class="btn btn-outline-primary btn-sm ms-1">
+      Registration Details <i class='fas fa-chevron-down'></i>
+    </button>
+  }
+  else
+  {
+    <button @onclick="@(e => ButtonClick(IsCollapsed))"
+            class="btn btn-outline-primary btn-sm ms-1">
+      Hide <i class='fas fa-chevron-up'></i>
+      @* Hide Registration Details *@
+    </button>
+  }
+
+  @if (!IsCollapsed)
+  {
+    <div class="card mt-1 mb-3">
+      <div class="card-body bg-light">
+        <EntryForm Email="@Email" Id="@Id" CurrentStep=CurrentStep OnUpdateCompleted="ReturnUpdateCompleted" />
+      </div>
+    </div>
+  }
+
+
+@code {
+  [Parameter, EditorRequired] public int Id { get; set; }
+  [Parameter, EditorRequired] public string? Email { get; set; }
+  [Parameter, EditorRequired] public Step? CurrentStep { get; set; }
+  //[Parameter, EditorRequired] public int Adults { get; set; }
+  [Parameter] public EventCallback<int> OnUpdateCompleted { get; set; }
+
+  public bool IsCollapsed { get; set; } = true;
+  protected void ButtonClick(bool isCollapsed)
+  {
+    IsCollapsed = !isCollapsed;
+  }
+
+  private void ReturnUpdateCompleted(int adults)
+  {
+    Logger!.LogDebug("{Method} {Message}", nameof(ReturnUpdateCompleted), $"pass through adults: {adults}");
+    if (!IsCollapsed) { IsCollapsed = true; }
+    OnUpdateCompleted.InvokeAsync(adults);
+  }
+}

--- a/LivingMessiah/Features/Sukkot/Print/Details.razor
+++ b/LivingMessiah/Features/Sukkot/Print/Details.razor
@@ -1,102 +1,129 @@
-﻿
-@using LivingMessiah.Features.Sukkot.Domain
+﻿@using LivingMessiah.Features.Sukkot.Data
 @using LivingMessiah.Features.Sukkot.Enums;
 
 <h4 class="my-4 text-center border-bottom border-dark-subtle border-4">@ConstantsPRINT.Details.Title</h4>
 
 <div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
 
-	<div class="d-flex justify-content-around">
-		<div><b>Name</b>: @vwRegistration!.FullName(false); <i>@vwRegistration!.OtherNames</i></div>
+  <div class="d-flex justify-content-around">
+    <div><b>Name</b>: @RegistrationQuery!.FullName(false); <i>@RegistrationQuery!.OtherNames</i></div>
 
-		<div><b>Registration#</b>: @vwRegistration!.Id</div>
-	</div>
+    <div><b>Registration#</b>: @RegistrationQuery!.Id</div>
+  </div>
 
-	<div class="d-flex justify-content-around">
-		<div><b>EMail / Phone</b>: @vwRegistration!.EMail @Phone2</div>
+  <div class="d-flex justify-content-around">
+    <div><b>EMail / Phone</b>: @RegistrationQuery!.EMail @Phone2</div>
 
-		<div class=" @Step.FromValue(vwRegistration.StepId).CardBodyCSS"><b>Step</b>: @vwRegistration.StepName</div>
+    <div class=" @Step.FromValue(RegistrationQuery.StepId).CardBodyCSS"><b>Step</b>: @RegistrationQuery.StepName</div>
 
-	</div>
+  </div>
 
 </div>
 
 @* House Rules Agreement *@
 <div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
-	<div class="d-flex justify-content-center">
-		<b>House Rules Agreement</b>:
-		Agreed on @vwRegistration!.HouseRulesAgreementDate
-	</div>
+  <div class="d-flex justify-content-center">
+    <b>House Rules Agreement</b>:
+    Agreed on @RegistrationQuery!.HouseRulesAgreementDate
+  </div>
 </div>
 
 
 @* Attendance *@
 
 <div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
-	<div class="d-flex justify-content-center">
-		<b>Attendance</b>:&nbsp;
-		<ul class="list-inline">
-			<li class="list-inline-item">Adults: <span class="">@vwRegistration!.Adults</span></li>
-			<li class="list-inline-item">Child (Big):<span class="">@vwRegistration!.ChildBig</span></li>
-			<li class="list-inline-item">Child (Small):<span class="">@vwRegistration!.ChildSmall</span></li>
-		</ul>
-	</div>
+  <div class="d-flex justify-content-center">
+    <b>Attendance</b>:&nbsp;
+    <ul class="list-inline">
+      <li class="list-inline-item">Adults: <span class="">@RegistrationQuery!.Adults</span></li>
+      <li class="list-inline-item">Child (Big):<span class="">@RegistrationQuery!.ChildBig</span></li>
+      <li class="list-inline-item">Child (Small):<span class="">@RegistrationQuery!.ChildSmall</span></li>
+    </ul>
+  </div>
 
-	<div class="@MediaQuery.Xs.DivClass">
-		<div class="d-flex justify-content-center mb-4">
-			<AttendanceDateCalendar IsXs="true"
-															AttendanceDateList="vwRegistration!.AttendanceDateList"
-															AttendanceDateList2ndMonth="vwRegistration!.AttendanceDateList2ndMonth">
-			</AttendanceDateCalendar>
-		</div>
-	</div>
+  <div class="@MediaQuery.Xs.DivClass">
+    <div class="d-flex justify-content-center mb-4">
+      <AttendanceDateCalendar IsXs="true"
+                              AttendanceDateList="RegistrationQuery!.AttendanceDateList"
+                              AttendanceDateList2ndMonth="RegistrationQuery!.AttendanceDateList2ndMonth">
+      </AttendanceDateCalendar>
+    </div>
+  </div>
 
 
-	<div class="@MediaQuery.SmOrMdOrLgOrXl.DivClass">
-		<div class="d-flex justify-content-center mb-4">
-			<AttendanceDateCalendar IsXs="false"
-															AttendanceDateList="vwRegistration!.AttendanceDateList"
-															AttendanceDateList2ndMonth="vwRegistration!.AttendanceDateList2ndMonth">
-			</AttendanceDateCalendar>
-		</div>
-	</div>
+  <div class="@MediaQuery.SmOrMdOrLgOrXl.DivClass">
+    <div class="d-flex justify-content-center mb-4">
+      <AttendanceDateCalendar IsXs="false"
+                              AttendanceDateList="RegistrationQuery!.AttendanceDateList"
+                              AttendanceDateList2ndMonth="RegistrationQuery!.AttendanceDateList2ndMonth">
+      </AttendanceDateCalendar>
+    </div>
+  </div>
 
 </div>
 
 @* Cost *@
 <div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
-	<div class="d-flex justify-content-center mb-2">
-		<span class="p-1"><b>Cost</b>:&nbsp;</span>
-		<span class="p-1 bg-danger-subtle text-black">@vwRegistration!.RegistrationFeeAdjusted.ToString("C0")</span>
-	</div>
+  <div class="d-flex justify-content-center mb-2">
+    <span class="p-1"><b>Registration Fee</b>:&nbsp;</span>
+    <span class="p-1 bg-warning-subtle text-black">
+      @Fee
+    </span>
+  </div>
 </div>
 
-@* Notes *@
-@if (!String.IsNullOrEmpty(vwRegistration!.Notes))
+@* Donation *@
+@if (RegistrationQuery.DonationQuery is not null)
 {
-	<div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
-		<div class="d-flex justify-content-center">
-			<b>Notes</b>: @vwRegistration!.Notes
-		</div>
-	</div>
+  <div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
+    <div class="d-flex justify-content-center mb-2">
+      <span class="p-1"><b>Paid Amount</b>:&nbsp;</span>
+      <span class="p-1 bg-warning-subtle text-black">@(RegistrationQuery.DonationQuery!.Amount.ToString("C2"))</span>
+    </div>
+    <div class="d-flex justify-content-center mb-2">
+      <span class="p-1"><b>Reference</b>:&nbsp;</span>
+      <span class="p-1 text-black"><small>@(RegistrationQuery.DonationQuery!.ReferenceId)</small></span>
+    </div>
+    <div class="d-flex justify-content-center mb-2">
+      <span class="p-1"><b>Date</b>:&nbsp;</span>
+      <span class="p-1 text-black">@(RegistrationQuery.DonationQuery!.CreateDate)</span>
+    </div>
+  </div>
+}
+
+@* Notes *@
+@if (!String.IsNullOrEmpty(RegistrationQuery!.Notes))
+{
+  <div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
+    <div class="d-flex justify-content-center">
+      <b>Notes</b>: @RegistrationQuery!.Notes
+    </div>
+  </div>
 }
 
 @* Address (print only) *@
 <div class="d-none d-print-block">
-	<div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
-		<div class="d-flex justify-content-center">
-			<Address OnOneLine="true" UseLabel="true" />
-		</div>
-	</div>
+  <div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
+    <div class="d-flex justify-content-center">
+      <Address OnOneLine="true" UseLabel="true" />
+    </div>
+  </div>
 </div>
 
 @code {
-	[Parameter, EditorRequired] public vwRegistration? vwRegistration { get; set; }
+  [Parameter, EditorRequired] public RegistrationQuery? RegistrationQuery { get; set; }
 
-	string Phone2 = string.Empty;
+  string Phone2 = string.Empty;
+  string Fee = "___";
 
-	protected override void OnParametersSet()
-	{
-		Phone2 = !String.IsNullOrEmpty(@vwRegistration!.Phone) ? $" / Phone: {@vwRegistration!.Phone} " : "";
-	}
+  protected override void OnParametersSet()
+  {
+    Phone2 = !String.IsNullOrEmpty(RegistrationQuery!.Phone) ? $" / Phone: {RegistrationQuery!.Phone} " : "";
+
+    if (RegistrationFee.TryFromValue(RegistrationQuery.FeeEnumValue, out var registrationFee))
+    {
+      Fee = registrationFee!.CurrencyFormat; 
+    }
+
+  }
 }

--- a/LivingMessiah/Features/Sukkot/Print/Index.razor
+++ b/LivingMessiah/Features/Sukkot/Print/Index.razor
@@ -17,11 +17,11 @@
 
 <AuthorizeView Policy=@Auth0.Policy.Name>
 	<Authorized>
-		<LoadingComponent IsLoading="vwRegistration == null" TurnSpinnerOff=TurnSpinnerOff>
+		<LoadingComponent IsLoading="RegistrationQuery == null" TurnSpinnerOff=TurnSpinnerOff>
 
 			@if (IsAuthorized)
 			{
-				<Details vwRegistration="@vwRegistration" />
+				<Details RegistrationQuery="@RegistrationQuery" />
 			}
 			else
 			{
@@ -43,7 +43,7 @@
 	string? Email;
 	protected bool IsAuthorized = false;
 
-	public Domain.vwRegistration? vwRegistration { get; set; }
+	public Data.RegistrationQuery? RegistrationQuery { get; set; }
 	private string[] OverrideRoles = new[] { Auth0.Roles.Sukkot, Auth0.Roles.Admin };
 
 	protected override async Task OnInitializedAsync()
@@ -58,11 +58,11 @@
 			}
 			else
 			{
-				vwRegistration = await db!.ById(Id);
+				RegistrationQuery = await db!.ById(Id);
 
-				if (vwRegistration is not null)
+				if (RegistrationQuery is not null)
 				{
-					var (passed, errorMsg, securityOverride) = await SecurityHelper!.DoAuthentication(Email!, vwRegistration.EMail ?? "");
+					var (passed, errorMsg, securityOverride) = await SecurityHelper!.DoAuthentication(Email!, RegistrationQuery.EMail ?? "");
 
 					if (passed)
 					{
@@ -99,9 +99,9 @@
 	private void DoPassed()
 	{
 		IsAuthorized = true;
-		(DateTime[]? week1, DateTime[]? week2) = EntryFormHelper.GetAttendanceDatesArray(vwRegistration!.AttendanceBitwise);
-		vwRegistration.AttendanceDateList = week1;
-		vwRegistration.AttendanceDateList2ndMonth = week2!;
+		(DateTime[]? week1, DateTime[]? week2) = EntryFormHelper.GetAttendanceDatesArray(RegistrationQuery!.AttendanceBitwise);
+		RegistrationQuery.AttendanceDateList = week1;
+		RegistrationQuery.AttendanceDateList2ndMonth = week2!;
 	}
 
 }

--- a/LivingMessiah/Features/Sukkot/RegistrationSteps/CurrentStepRecord.cs
+++ b/LivingMessiah/Features/Sukkot/RegistrationSteps/CurrentStepRecord.cs
@@ -1,5 +1,0 @@
-﻿namespace LivingMessiah.Features.Sukkot.RegistrationSteps;
-
-// is FirstName and /or FamilyName ever used?
-public record CurrentStepRecord(int Id, string? FirstName, string? FamilyName = "" );
-

--- a/LivingMessiah/Features/Sukkot/RegistrationSteps/HorizontalStep.razor
+++ b/LivingMessiah/Features/Sukkot/RegistrationSteps/HorizontalStep.razor
@@ -26,8 +26,17 @@
 
 	protected string FontSize => $"{(IsXs ? " fs-4" : " fs-2")}";
 
-	private string GetIcon(int stepId) =>
-		EnumStep < CurrentStep!.Value ? "far fa-check-square text-dark" : "far fa-square text-black-50";
+	private string GetIcon(int stepId)
+	{
+		if (EnumStep < CurrentStep!.Value)
+		{
+			return "far fa-check-square text-dark";
+		}
+		else
+		{
+			return "far fa-square text-black-50";
+		}
+	}
 
 	private string GetBorder() =>
 		EnumStep == CurrentStep!.Value ? StepConstants.Border : "";

--- a/LivingMessiah/Features/Sukkot/RegistrationSteps/Index.razor
+++ b/LivingMessiah/Features/Sukkot/RegistrationSteps/Index.razor
@@ -25,7 +25,7 @@
 
       <p class="text-center fs-5 py-2 mb-0 @StepConstants.Border @CurrentStep.CardBodyCSS">
         <b>Step:</b> @CurrentStep.Value
-        <i class="@CurrentStep).Icon"></i>
+        @* <i class="@CurrentStep).Icon"></i> *@
         @CurrentStep.Heading
       </p>
     }
@@ -34,7 +34,7 @@
     {
       <div class="card mt-0 mb-3 @CurrentStep!.CardBodyCSS">
         <div class="card-body @CurrentStep!.CardBodyCSS">
-          <HRAWrapper EmailParm="@Email" OnActionCompleted="ReturnedActionCompleted" />
+          <HRAWrapper EmailParm="@Email" OnActionCompleted="ReturnedHraActionCompleted" />
         </div>
       </div>
     }
@@ -51,19 +51,21 @@
             <div class="card mt-0 mb-3 @CurrentStep!.CardBodyCSS">
               <div class="card-body @CurrentStep!.CardBodyCSS">
                 <EntryForm Email="@Email" Id="null"
-                           OnActionCompleted="ReturnedActionCompleted" />
+                           CurrentStep="CurrentStep"
+                           OnAddCompleted="ReturnedRegistrationAddCompleted" />
               </div>
             </div>
 
-            @if (vm.Step!.EnableRegistrationToggleButton && vm.CurrentStepRecord is not null)
+            @* ToDo: Why is this here? *@
+            @if (vm.Step!.RegistrationExists && CurrentRegistrationId != 0)
             {
-              <Toggle Email="@Email" Id="@vm.CurrentStepRecord!.Id" />
+              <Toggle Email="@Email" Id="CurrentRegistrationId" CurrentStep="CurrentStep" />
             }
           }
         </RegistrationFormRF>
 
         <PaymentRF>
-          @if (@vm.Step == Step.Payment && vm.CurrentStepRecord is not null)
+          @if (@vm.Step == Step.Payment && CurrentRegistrationId != 0)
           {
             <div class="card my-2 @CurrentStep!.CardBodyCSS">
               <div class="card-body">
@@ -74,14 +76,13 @@
                 </p>
               </div>
               <div class="card-body">
-                @* @vm.FeeEnumValue needs to be CurrentFeeNumValue and it needs to be updated when the EditForm is Updated *@
-                <StripeCard RegistrationFee="@RegistrationFee.FromValue(@vm.FeeEnumValue)"
+                <StripeCard RegistrationFee="CurrentRegistrationFee"
                             Email="@vm.EmailAddress"
-                            RegistrationId="@vm!.CurrentStepRecord.Id" />
+                            RegistrationId="CurrentRegistrationId" />
               </div>
 
-              <div class="card-footer bg-body-secondary">
-                <AlternativePaymentsToggle Id="vm!.CurrentStepRecord.Id" />
+              <div class="card-body">
+                <AlternativePaymentsToggle Id="CurrentRegistrationId" />
               </div>
             </div>
           }
@@ -92,7 +93,7 @@
           {
             <div class="card mt-0 mb-3 @CurrentStep!.CardBodyCSS">
               <div class="card-body">
-                <CompleteParagraph Id="@vm.CurrentStepRecord!.Id" />
+                <CompleteParagraph Id="CurrentRegistrationId" />
               </div>
             </div>
           }
@@ -100,17 +101,15 @@
 
       </StepSkeleton>
 
-      @* 
-        "Footer" 
-        ToDo: Comment this out
-      *@
-      @if (vm.CurrentStepRecord is not null)
+      @if (CurrentRegistrationId != 0)
       {
-        <Toggle Email="@Email" Id="vm.CurrentStepRecord.Id" />
-      }
-      else
-      {
-        <Toggle Email="@Email" Id="null" />
+        <PrintButton Id="CurrentRegistrationId" />
+
+        <UpdateRegistrationToggle Email="@Email"
+                                  Id="CurrentRegistrationId"
+                                  CurrentStep="CurrentStep"
+                                  OnUpdateCompleted="ReturnedRegistrationUpdateCompleted" />
+
       }
 
     </LoadingComponent>
@@ -124,6 +123,8 @@
 @code {
 
   protected Step? CurrentStep;
+  protected RegistrationFee? CurrentRegistrationFee;
+  protected int CurrentRegistrationId = 0;
 
   protected bool TurnSpinnerOff = false;
   string? Email;
@@ -158,16 +159,19 @@
 
         if (vw.RegistrationId is not null)
         {
-          vm!.CurrentStepRecord = new CurrentStepRecord((int)vw.RegistrationId, vw.FirstName, vw.FamilyName);
+          vm!.RegistrationId = (int)vw.RegistrationId;
           vm!.Step = Step.FromValue((int)vw.StepId!);
           vm.Adults = vw.Adults ?? 0; // this can't be null if there is a RegistrationId
-          vm.FeeEnumValue = (int)vw.FeeEnumValue!; // this can't be null if there is a RegistrationId  
+          vm.FeeEnumValue = (int)vw.FeeEnumValue!; // this can't be null if there is a RegistrationId
+          CurrentRegistrationId = vm!.RegistrationId;
           CurrentStep = vm!.Step;
+          CurrentRegistrationFee = RegistrationFee.FromValue(vm.FeeEnumValue);
         }
         else
         {
           vm!.Step = Step.Registration;
           CurrentStep = Step.FromValue(vm.Step!.Value);
+          //CurrentRegistrationId = 0;  //ToDo: review.
         }
       }
       else
@@ -189,10 +193,24 @@
     }
   }
 
-  private async Task ReturnedActionCompleted(Step nextStep)
+  private async Task ReturnedHraActionCompleted(Step nextStep)
+  {
+    CurrentStep = nextStep;
+    await ProcessRegistrationStep();
+  }
+
+  private async Task ReturnedRegistrationAddCompleted(StepAndRegFee nextStepRegFee)
   {
     //Logger!.LogDebug("{Method}, {Step}", nameof(ReturnedActionCompleted), nextStep);
-    CurrentStep = nextStep;
+    CurrentStep = nextStepRegFee.Step;
+    CurrentRegistrationFee = nextStepRegFee.RegistrationFee;
+    await ProcessRegistrationStep();
+  }
+
+  private async Task ReturnedRegistrationUpdateCompleted(int adults)
+  {
+    //Logger!.LogDebug("{Method}, {Step}", nameof(ReturnedActionCompleted), nextStep);
+    CurrentRegistrationFee = RegistrationFeeHelper.AdultsToRegistrationFee(adults);
     await ProcessRegistrationStep();
   }
 

--- a/LivingMessiah/Features/Sukkot/RegistrationSteps/IndexVM.cs
+++ b/LivingMessiah/Features/Sukkot/RegistrationSteps/IndexVM.cs
@@ -5,25 +5,10 @@ namespace LivingMessiah.Features.Sukkot.RegistrationSteps;
 public class IndexVM
 {
 	public string? EmailAddress { get; set; } 
+	public int RegistrationId { get; set; }
 	public int Adults { get; set; } // If null then set to zero
 	public int FeeEnumValue { get; set; }	
 	public Step? Step { get; set; } 
 	public HRARecord? HouseRulesAgreement { get; set; }
-	public CurrentStepRecord? CurrentStepRecord { get; set; }
 
-	/*
-	ToDo Use RegistrationFeeHelper.AdultsToRegistrationFee(Adults)
-	
-using RegistrationFeeEnums = LivingMessiah.Features.Sukkot.Enums;
-
-	public RegistrationFeeEnums.RegistrationFee? RegistrationFee
-	{
-		get
-		{
-			return Adults > 1
-				? RegistrationFeeEnums.RegistrationFee.Family
-				: RegistrationFeeEnums.RegistrationFee.Single;
-		}
-	}
-	*/
 }

--- a/LivingMessiah/Features/Sukkot/RegistrationSteps/PaymentStep/AlternativePaymentsToggle.razor
+++ b/LivingMessiah/Features/Sukkot/RegistrationSteps/PaymentStep/AlternativePaymentsToggle.razor
@@ -1,6 +1,6 @@
 ﻿
 
-<div class="d-flex justify-content-end mt-2">
+<div class="d-flex justify-content-center">
   @if (IsCollapsed)
   {
     <button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
@@ -15,8 +15,8 @@
       Hide <i class='fas fa-chevron-up'></i>
     </button>
   }
-
 </div>
+
 
 @if (!IsCollapsed)
 {


### PR DESCRIPTION

### Tasks
- [x] Add UpdateRegistrationToggle.razor
- [x] Keep `EntryForm.razor` from Updating Adults if  `Step` == Complete 
  - [x] Adults can be populated when Action is `Create` to which only occurs when `Step` == Registration 
  - [x] Adults can be updated when Action is `Update` but only if  `Step` == Payment (to make a donation)

- [x] With `EntryForm.razor` if  `Step` == Payment and if Adults is updated then...
-  [x]StripeCard!Stripe Processing button needs to be refreshed
-  [x]The `<p class="mt-0"><small>Amount @RegistrationFee!.CurrencyFormat</small></p>` needs to be refreshed
-  [x]the `<input type="hidden" name="@FormFields.RegistrationId" value="@RegistrationId" />` needs to be refreshed

- [x] Got Print\Details.razor to print donations
  - [x] Donation Component Update
  - [x] Added DonationQuery (Sukkot/Data)
  - [x] Added RegistrationQuery (Sukkot/Data)
  - [x] Repository!GetById() uses both the above new classes which replaced `Domain.vwRegistrations` (and it was deleted)
  - [ ] Move these two new query models to Print\
  - [ ] Test Print after adding registration and before making a donation

- [x] EntryForm.razor (/NormalUser) lots of changes
  - [x] Added StepAndRegFee record
  - [x] Added UpdateRegistrationToggle which 
    - [x] `<EntryForm Email="@Email" Id="@Id" CurrentStep=CurrentStep OnUpdateCompleted="ReturnUpdateCompleted" />`
    - [x] No Print button (this is in Index.razor)
  
  - [ ] Tried to fix HorizontalStep with Complete check box not getting checked....don't know if I can
  - [ ] Got rid of `CurrentStepRecord` in IndexVM



### Database Tasks
- [x] stpDonationInsert refactored; removed the multi-donation logic and make Detail as be 1
- [ ] run on Azure

