### PR TITLE
Ported Notes and HRA

### DIFF
--- a/LivingMessiahAdmin/Components/App.razor
+++ b/LivingMessiahAdmin/Components/App.razor
@@ -21,6 +21,8 @@
 	@* <link href="css/syncfusion-blazor-icons.css" rel="stylesheet" /> *@
 	<link href="LivingMessiahAdmin.styles.css" rel="stylesheet" /> <!-- FN:1 Blazored Toast -->
 
+	<link href="_content/Blazored.Typeahead/blazored-typeahead.css" rel="stylesheet" />
+
 	@* <script src="_content/Syncfusion.Blazor.Core/scripts/syncfusion-blazor.min.js" type="text/javascript"></script> *@
 	@* <script async src="https://js.stripe.com/v3/buy-button.js"> </script> *@
 	<ImportMap />
@@ -30,6 +32,7 @@
 <body>
 	<Routes @rendermode="InteractiveServer" />
 	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+	<script src="_content/Blazored.Typeahead/blazored-typeahead.js"></script>
 	<script src="_framework/blazor.web.js"></script>
 </body>
 

--- a/LivingMessiahAdmin/Features/Sukkot/Constants/Documents.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Constants/Documents.cs
@@ -1,0 +1,28 @@
+﻿namespace LivingMessiahAdmin.Features.Sukkot.Constants;
+
+public static class Documents
+{
+	private const string PdfBlobFolder = "https://livingmessiahstorage.blob.core.windows.net/pdfs/";
+	
+	public static class PDFs
+	{
+		public const string Schedule = "sukkot-2025-schedule.pdf";
+		public const string LiabilityWaiver = "sukkot-2022-liability-waiver.pdf"; // NOT DONE YET
+		public const string HouseRules = "sukkot-2025-house-rules.pdf";
+		public const string WindmillRanchSurroundingArea = "windmill-ranch-surrounding-area.pdf";
+	}
+
+	public static string Url(string blob) => PdfBlobFolder + blob;
+
+
+	//public static string UrlPDF(string blob)
+	//{
+	//	return PdfBlobFolder + blob;
+	//}
+
+	//public static class PdfBlobFolder
+	//{
+	//	private const string pdf = "https://livingmessiahstorage.blob.core.windows.net/pdfs/";
+	//}
+
+}

--- a/LivingMessiahAdmin/Features/Sukkot/Constants/Pages.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Constants/Pages.cs
@@ -4,7 +4,7 @@ public static class Pages
 {
 	public static class ManageRegistration
 	{
-		public const string Index = "Sukkot/ManageRegistration";
+		public const string Index = "/Sukkot";
 		public const string Title = "Manage Registration";
 		public const string IconText = "Manage Registration";
 		public const string Icon = "fas fa-mask";
@@ -12,25 +12,25 @@ public static class Pages
 
 	public static class ManageNotes
 	{
-		public const string Index = "/SukkotAdmin/Notes";
+		public const string Index = "/Sukkot/Notes";
 		public const string Title = "Sukkot Registration Notes";
 		public const string IconText = "Notes";
 		public const string Icon = "far fa-sticky-note";
 	}
 
-	public const string AttendanceAllFeastDays = "/SukkotAdmin/AttendanceAllFeastDays";
-	public const string AttendanceChart = "/SukkotAdmin/AttendanceChart";
+	public const string AttendanceAllFeastDays = "/Sukkot/AttendanceAllFeastDays";
+	public const string AttendanceChart = "/Sukkot/AttendanceChart";
 
 	public static class Donations
 	{
-		public const string Grid = "/SukkotAdmin/DonationsGrid";
+		public const string Grid = "/Sukkot/DonationsGrid";
 		public const string GridTitle = "Sukkot Admin DonationsGrid";
-		public const string CreateDonation = "/SukkotAdmin/CreateDonation";
+		public const string CreateDonation = "/Sukkot/CreateDonation";
 	}
 
 	public static class LegalAgreementVerbiage
 	{
-		public const string Index = "/SukkotAdmin/LegalAgreementVerbiage";
+		public const string Index = "/Sukkot/LegalAgreementVerbiage";
 		public const string Title = "Legal Agreement Verbiage";
 		public const string Icon = "fas fa-balance-scale";  // "fas fa-handshake" "far fa-handshake"
 	}

--- a/LivingMessiahAdmin/Features/Sukkot/LegalAgreementVerbiage/AgreementButtonsMockup.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/LegalAgreementVerbiage/AgreementButtonsMockup.razor
@@ -1,0 +1,41 @@
+﻿
+<div class="row col-12 my-2">
+	<div class="mb-3">
+
+		<button @onclick="@(() => DoNotAgree_ButtonClick())"
+						class="btn btn-danger">
+			<i class="far fa-hand-paper"></i> No, I Do NOT Agree
+		</button>
+
+		<button @onclick="@(() => Agree_ButtonClick())"
+						class="btn btn-success">
+			<i class="fas fa-check"></i> Yes, I Agree
+		</button>
+
+	</div>
+</div>
+
+@code {
+	[Parameter, EditorRequired] public string? EmailParm { get; set; }
+	[Inject] public IToastService? Toast { get; set; }
+
+	void DoNotAgree_ButtonClick()
+	{
+		Toast!.ShowWarning("Not agreeing to the House Rules Agreement terminates the Registration Process");
+	}
+
+	private void Agree_ButtonClick()
+	{
+		Toast!.ShowInfo($"House Rules Agreement as been recorded for {EmailParm} on {GetLocalTimeZone()} Local Time");
+		//int id = 0;
+		//id = await svc.AddHouseRulesAgreementRecord(EmailParm, GetLocalTimeZone());
+		//AppState.UpdateMessage(this, "Record updated for House Rules Agreement");
+	}
+
+	private string GetLocalTimeZone()
+	{
+		return $"Time Zone: {TimeZoneInfo.Local}.";
+	}
+
+}
+

--- a/LivingMessiahAdmin/Features/Sukkot/LegalAgreementVerbiage/Index.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/LegalAgreementVerbiage/Index.razor
@@ -1,0 +1,80 @@
+﻿@page "/Sukkot/LegalAgreementVerbiage/"
+
+@* 
+
+Compare with LivingMessiah\Features\Sukkot\RegistrationSteps\Agreement\HRAWrapper.razor
+
+@using static LivingMessiahAdmin.Services.Auth0
+@using LivingMessiahAdmin.Features.Sukkot.RegistrationSteps
+@using LivingMessiahAdmin.Shared.Sukkot 
+@using Page = LivingMessiahAdmin.Links.Sukkot.LegalAgreementVerbiage
+*@
+
+@using Page = LivingMessiahAdmin.Features.Sukkot.Constants.Pages.LegalAgreementVerbiage
+
+<PageTitle>@Page.Title</PageTitle>
+@* 
+<AuthorizeView Roles="@Roles.SukkotMenuBar">
+	<SukkotAdminMenubar></SukkotAdminMenubar>
+</AuthorizeView>
+
+<div class="pb-2 mt-4 mb-2">
+	<h2><i class="@Page.Icon"></i> @Page.Title</h2>
+</div>
+
+ *@
+<div class="card mt-0 mb-3">
+	<div class="card-body border-info">
+		<p>
+			This is a mock-up of the legal verbiage that is shown to new registrants.
+			This is <b>Step 3 - Sign Agreement</b> in the registration process.
+			It also includes the buttons to show the full process of compliance.
+			Note, clicking the buttons will not actually be recorded.
+		</p>
+	</div>
+
+	<div class="card-body border-info">
+		<p>
+			Should something like this be included? <br />
+			<b>If a conflict arises the decisions will be made by the Elders and those decisions are final.</b>
+			<br /><br />
+			I think there should be a reference to the process of Matthew 18 included as well.
+		</p>
+	</div>
+
+</div>
+
+
+<h4 class="mb-3">To register for Sukkot, you must complete these steps</h4>
+
+@* <div class="d-block d-md-none"></div> *@
+
+	<div class="card mt-0 mb-3">
+		<div class="card-body bg-light">
+			<VerbiageParagraph />
+			<AgreementButtonsMockup EmailParm="FAKE@EMAIL" /> 
+		</div>
+	</div>
+
+@*
+
+<div class="d-none d-md-block">
+	<VerbiageParagraph IsXs="false"></VerbiageParagraph>
+	<AgreementButtonsMockup EmailParm="FAKE@EMAIL" />
+</div>
+
+
+	<ul class="lead">
+	<li>
+	<b>alternative dispute resolution</b>:
+	It is like when people register to attend Living Messiah sponsored <i>Sukkot</i> gatherings where the registrant agrees to the rules defined in the registration form.
+	<b>If a conflict arises the decisions will be made by the Elders and those decisions are final.</b>
+	The church can not be a fully sovereign entity until is re-establishes its jurisdiction and create
+	<a href="https://myhebrewbible.com/Article/899/1Co-06-1-11-Legal-Matters-Between-The-Brethren-Courts-of-Ecclesia">Courts of Ecclesia <i class="fas fa-external-link-alt"></i></a>.
+	</li>
+	</ul>
+*@
+
+@code {
+
+}

--- a/LivingMessiahAdmin/Features/Sukkot/LegalAgreementVerbiage/VerbiageParagraph.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/LegalAgreementVerbiage/VerbiageParagraph.razor
@@ -1,0 +1,26 @@
+﻿@using LivingMessiahAdmin.Features.Sukkot.Constants
+
+<h2 class="text-primary">House Rules Confirmation</h2>
+<ul class="fs-5">
+	<li>
+		<i>Living Messiah Sukkot @CurrentYear.Title </i> is an event wholly sponsored by Living Messiah and is a private event <b><u>NOT open to the public</u></b>.
+	</li>
+
+	<li>If you have not been pre-approved by an invitation email <sup><i class="far fa-envelope"></i></sup> the approval process will be initiated upon completion of the registration application form.</li>
+	<li>
+		Regardless of pre-approval to attend this event you <b><u>must</u></b> fill out the registration application form and sign the <b><u>liability waiver form</u></b>.
+		<ul class="fs-5">
+			<li>
+				<a class="btn btn-sm btn-info" href="@Documents.Url(@Documents.PDFs.LiabilityWaiver)"
+					 target="_blank">
+					<i class="fas fa-file-pdf"></i> Liability Waiver Form <i class='fas fa-external-link-square-alt'></i>
+				</a> Please Sign
+			</li>
+		</ul>
+	</li>
+	<li>The approval process is done by the Elders of Living Messiah.</li>
+</ul>
+
+@code {
+
+}

--- a/LivingMessiahAdmin/Features/Sukkot/ManageRegistration/Data/ServiceCollectionExtensions.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/ManageRegistration/Data/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation;
+﻿//using FluentValidation;
 
 namespace LivingMessiahAdmin.Features.Sukkot.ManageRegistration.Data;
 

--- a/LivingMessiahAdmin/Features/Sukkot/ManageRegistration/Detail/Report.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/ManageRegistration/Detail/Report.razor
@@ -130,7 +130,7 @@
     {
       Logger!.LogDebug("{Method} {Id}", nameof(OnParametersSetAsync), RegistrationId);
       data = await db!.ById(RegistrationId);
-      if (data is not null) { ProcessDataFount(); }
+      if (data is not null) { ProcessDataFound(); }
     }
     catch (Exception ex)
     {
@@ -143,7 +143,7 @@
     }
   }
 
-  private void ProcessDataFount()
+  private void ProcessDataFound()
   {
     Phone2 = !String.IsNullOrEmpty(data!.Phone) ? $" / Phone: {data!.Phone} " : "";
 

--- a/LivingMessiahAdmin/Features/Sukkot/Notes/Data/Repository.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Notes/Data/Repository.cs
@@ -1,0 +1,43 @@
+﻿using Dapper;
+using LivingMessiahAdmin.Data;
+using DataEnumsDatabase = LivingMessiahAdmin.Data.Enums.Database;
+
+namespace LivingMessiahAdmin.Features.Sukkot.Notes.Data;
+
+public interface IRepository
+{
+	string BaseSqlDump { get; }
+
+	Task<List<NotesQuery>> GetAdminOrUserNotes(Enums.Filter filter);
+}
+
+public class Repository : BaseRepositoryAsync, IRepository
+{
+	public Repository(IConfiguration config, ILogger<Repository> logger)
+		: base(config, logger, DataEnumsDatabase.Sukkot.ConnectionStringKey)
+	{
+	}
+
+	public string BaseSqlDump
+	{
+		get { return SqlDump!; }
+	}
+
+	// Only NotesEnum.All.SqlWhere and NotesEnum.All.SqlOrder are used
+	public async Task<List<NotesQuery>> GetAdminOrUserNotes(Enums.Filter filter)
+	{
+		Sql = $@"
+SELECT TOP 500 Id, FirstName, FamilyName, AdminNotes, Notes AS UserNotes, Phone, EMail
+FROM Sukkot.vwRegistration
+{filter.SqlWhere}
+{filter.SqlOrder}
+";
+		Logger!.LogDebug("{Method}, {Message}", nameof(GetAdminOrUserNotes), $"filter: {filter.Name}");
+		return await WithConnectionAsync(async connection =>
+		{
+			var rows = await connection.QueryAsync<NotesQuery>(sql: Sql);
+			return rows.ToList();
+		});
+	}
+
+}

--- a/LivingMessiahAdmin/Features/Sukkot/Notes/Data/ServiceCollectionExtensions.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Notes/Data/ServiceCollectionExtensions.cs
@@ -1,0 +1,12 @@
+﻿namespace LivingMessiahAdmin.Features.Sukkot.Notes.Data;
+
+public static class ServiceCollectionExtensions
+{
+	public static IServiceCollection AddManageNotes(this IServiceCollection services)
+	{
+		services
+			.AddSingleton<IRepository, Repository>();
+		
+		return services;
+	}
+}

--- a/LivingMessiahAdmin/Features/Sukkot/Notes/DetailsCard.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/Notes/DetailsCard.razor
@@ -1,0 +1,106 @@
+﻿@using Microsoft.Extensions.Logging
+@using CrudEnums = LivingMessiahAdmin.Features.Sukkot.MasterDetail.Enums.Crud
+
+@inject ILogger<DetailsCard>? Logger
+@inject IToastService? Toast
+@inject Data.IRepository? db
+
+@if (CurrentNote is not null)
+{
+  <div class="card text-dark bg-light my-4">
+    <div class="card-header">
+
+      <div class="container d-flex justify-content-between">
+        <p><b>@CurrentNote.FirstName @CurrentNote.FamilyName</b></p>
+        <p>
+          <a href="tel:@CurrentNote.Phone" title="@CurrentNote.PhoneNumber">@CurrentNote.PhoneNumber</a>&nbsp;<i class="fa fa-phone"></i>
+        </p>
+        <p>
+          <a href="mailto:@CurrentNote.EMail" title="@CurrentNote.EMail">@CurrentNote.EMail</a>&nbsp;<i class="far fa-envelope"></i>
+        </p>
+      </div>
+
+    </div>
+
+    @* 
+			ToDo: replace this with an EditForm that can update these two fields 
+			Use Markdown by implementing MarkDig
+		*@
+    <div class="row">
+      <div class="col-sm-6">
+
+        <div class="card-body">
+          <h5 class="card-title">
+            <b>Admin Notes</b>
+            <button @onclick="() => EditButtonClicked(true)" class="btn-outline-primary btn btn-xs">
+              <i class=@CrudEnums.Edit.Icon></i>
+            </button>
+          </h5>
+          <p class="card-text bg-secondary-subtle p-1">@CurrentNote.AdminNotes </p>
+        </div>
+
+      </div>
+      <div class="col-sm-6">
+
+        <div class="card-body">
+          <h5 class="card-title">
+            <b>User Notes</b>
+            <button @onclick="() => EditButtonClicked(false)" class="btn-outline-primary btn btn-xs">
+              <i class=@CrudEnums.Edit.Icon></i>
+            </button>
+          </h5>
+          <p class="card-text bg-secondary-subtle p-1">@CurrentNote.UserNotes </p>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="d-print-none">
+      <div class="card-footer text-center">
+        <button @onclick="CloseButtonClicked" class="btn-primary btn btn-sm">
+          Close <i class='fas fa-times'></i>
+        </button>
+      </div>
+    </div>
+
+  </div>
+}
+else
+{
+  <p class="text-black-50"><small>CurrentNote IS NULL</small></p>
+}
+
+@code {
+  [Parameter, EditorRequired] public required NotesQuery? SelectedNote { get; set; }
+  [Parameter] public EventCallback OnCommandDetailClosed { get; set; }
+
+  protected NotesQuery? CurrentNote { get; set; }
+
+  protected override void OnParametersSet()
+  {
+    string inside = $"{nameof(DetailsCard)}!{nameof(OnParametersSet)}";
+    Logger!.LogDebug(string.Format("Inside {0}", inside));
+
+    if (SelectedNote is not null)
+    {
+      CurrentNote = SelectedNote; // ToDo is this necessary?
+
+      Logger!.LogDebug(string.Format("...CurrentNote.FirstName: {0}", CurrentNote.FirstName));
+    }
+    else
+    {
+      Logger!.LogDebug("{Method} {Message}", nameof(OnParametersSet), "SelectedNote is null");
+    }
+  }
+
+  void EditButtonClicked(bool isAdmin)
+  {
+    Toast!.ShowInfo("ToDo: call db to update Note or AdminNotes");
+  }
+
+  void CloseButtonClicked()
+  {
+
+    OnCommandDetailClosed.InvokeAsync();
+  }
+}

--- a/LivingMessiahAdmin/Features/Sukkot/Notes/Enums/Filter.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Notes/Enums/Filter.cs
@@ -1,0 +1,69 @@
+﻿using Ardalis.SmartEnum;
+
+namespace LivingMessiahAdmin.Features.Sukkot.Notes.Enums;
+
+// ToDo Rename as Filter
+public abstract class Filter : SmartEnum<Filter>
+{
+		#region Id's
+		private static class Id
+		{
+				internal const int All = -1;
+				// 0=None
+				internal const int Admin = 1;
+				internal const int User = 2;
+		}
+		#endregion
+
+		#region Declared Public Instances
+		public static readonly Filter All = new AllSE();
+		public static readonly Filter Admin = new AdminSE();
+		public static readonly Filter User = new UserSE();
+		// Note: SE=SmartEnum
+		#endregion
+
+		private Filter(string name, int value) : base(name, value) { } // Constructor
+
+		#region Extra Fields
+		public abstract string CssBgColor { get; }
+		public abstract string CssTextColor { get; }
+		public abstract string SqlWhere { get; }
+		public abstract string SqlOrder { get; }
+		#endregion
+
+		#region Private Instantiation
+		private sealed class AllSE : Filter
+		{
+				public AllSE() : base($"{nameof(Id.All)}", Id.All) { }
+				public override string CssBgColor => "bg-warning";
+				public override string CssTextColor => "btn-outline-success";
+				public override string SqlWhere => @"
+WHERE
+	(AdminNotes IS NOT NULL OR TRIM(AdminNotes) <> '')
+OR
+	(Notes IS NOT NULL AND TRIM(Notes) <> '')
+";
+				public override string SqlOrder => " ORDER BY FirstName";
+		}
+
+		private sealed class AdminSE : Filter
+		{
+				public AdminSE() : base($"{nameof(Id.Admin)}", Id.Admin) { }
+				public override string CssBgColor => "bg-warning";
+				public override string CssTextColor => "btn-outline-warning";
+				public override string SqlWhere => " WHERE AdminNotes IS NOT NULL AND TRIM(AdminNotes) <> ''";
+				public override string SqlOrder => " ORDER BY FirstName";
+		}
+
+		private sealed class UserSE : Filter
+		{
+				public UserSE() : base($"{nameof(Id.User)}", Id.User) { }
+				public override string CssBgColor => "bg-info";
+				public override string CssTextColor => "btn-outline-primary";
+				public override string SqlWhere => " WHERE Notes IS NOT NULL AND TRIM(Notes) <> ''";
+				public override string SqlOrder => " ORDER BY FirstName";
+		}
+		#endregion
+
+}
+// Ignore Spelling: Css

--- a/LivingMessiahAdmin/Features/Sukkot/Notes/FilterButtons.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/Notes/FilterButtons.razor
@@ -1,0 +1,27 @@
+﻿@using Microsoft.Extensions.Logging;
+
+ <div class="d-print-none mb-2">
+	<div class="container d-flex justify-content-end mt-2">
+
+		@foreach (var item in Enums.Filter.List.OrderBy(o => o.Value))
+		{
+			<button @onclick="@(() => OnButtonClicked(item))"
+							class="btn @item.CssTextColor btn-sm @ActiveFilter(item)">
+				@item.Name &nbsp;<i class="fas fa-chevron-circle-right"></i>
+			</button>
+		}
+
+	</div>
+</div>
+
+@code {
+	[Parameter, EditorRequired] public required Enums.Filter? Filter { get; set; }
+	[Parameter] public EventCallback<Enums.Filter> OnFilterSelected { get; set; }
+
+	public string ActiveFilter(Enums.Filter filter) => filter == Filter ? "active" : "";
+	
+	private void OnButtonClicked(Enums.Filter filter)
+	{
+		OnFilterSelected.InvokeAsync(filter); 
+	}
+}

--- a/LivingMessiahAdmin/Features/Sukkot/Notes/Index.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/Notes/Index.razor
@@ -1,12 +1,114 @@
 ﻿@page "/Sukkot/Notes"
 
 @using Page = LivingMessiahAdmin.Enums.Nav
-<PageHeader PageEnum="Page.SukkotNotes" />
 
-<div class="alert alert-warning text-center" role="alert">
-	<b>Note:</b> This page has not yet been ported over from an older version
+@inject ILogger<Index>? Logger
+@inject IToastService? Toast
+@inject Data.IRepository? db
+
+
+@* 
+<AuthorizeView Roles="@Roles.AdminOrSukkot">
+	<Authorized>
+	</Authorized>
+	<NotAuthorized>
+	</NotAuthorized>
+</AuthorizeView>
+*@
+
+<div class="d-print-none">
+  <a class="btn btn-sm btn-default float-end" href="javascript:window.print()">
+    <span class="fa fa-print"></span> Print
+  </a>
 </div>
 
+@* 
+  ToDo: can I use this? 
+    <PageHeader PageEnum="Page.SukkotNotes" /> 
+  ToDo: if so, can I incorporate the print button and push it to the right?
+*@
+<div class="pb-2 mt-4 mb-2 border-bottom">
+  <h3> <span class="text-warning"><i class="fa fa-sticky-note"></i></span> @Page.SukkotNotes.Title</h3>
+</div>
+
+<LoadingComponent IsLoading="data == null" TurnSpinnerOff=TurnSpinnerOff>
+  @if (ShowDetail)
+  {
+    <DetailsCard SelectedNote="CurrentNote" OnCommandDetailClosed="ReturnedCommandDetailClose" />
+  }
+  else
+  {
+    @* @if (data is not null)  {  } *@
+    <div class="row">
+      <div class="col-sm-6">
+        <Typeahead SelectedNote="CurrentNote"
+                   OnNotesQuerySelected="ReturnedNotesQuery"
+                   data="data" />
+      </div>
+      <div class="col-sm-6">
+        <FilterButtons Filter="Filter" OnFilterSelected="ReturnedFilter" />
+      </div>
+    </div>
+
+    <ListCard Filter="Filter" data="data" />
+  }
+</LoadingComponent>
+
 @code {
+
+  List<NotesQuery>? data = new List<NotesQuery>();
+
+  protected bool TurnSpinnerOff = false;
+  protected override async Task OnInitializedAsync()
+  {
+    try
+    {
+      //Logger!.LogDebug("{Method}, Filter: {Message}", nameof(OnInitializedAsync), CurrentFilter?.Name);
+      await Task.Delay(500); // To allow the spinner to show  
+      // ToDo: Note, Filter is always going to be All, because we are in OnInitializedAsync
+      data = await db!.GetAdminOrUserNotes(Filter!);
+      if (data is null)
+      {
+        Logger!.LogDebug("{Method} {Message}", nameof(OnInitializedAsync), "data is null");
+        Toast!.ShowInfo("No notes to display");
+      }
+    }
+    catch (Exception ex)
+    {
+      Logger!.LogError(ex, "{Method}", nameof(OnInitializedAsync));
+      Toast!.ShowError("An invalid operation occurred, contact your administrator");
+    }
+    finally
+    {
+      TurnSpinnerOff = true;
+    }
+  }
+
+
+  private bool ShowDetail = false;
+  protected NotesQuery? CurrentNote { get; set; }
+  // Called by Typeahead
+  void ReturnedNotesQuery(NotesQuery notesQuery)
+  {
+    ShowDetail = true;
+    CurrentNote = notesQuery;
+    /*
+    Logger!.LogDebug("{Method}, {Message}"
+    , nameof(ReturnedNotesQuery)
+    , $"{notesQuery?.FirstName} {notesQuery?.FamilyName}, Id: {notesQuery?.Id}; ShowDetail: {ShowDetail}");
+    */
+  }
+
+  private Enums.Filter? Filter = Enums.Filter.All;
+  void ReturnedFilter(Enums.Filter filter)
+  {
+    Filter = filter;
+  }
+
+  void ReturnedCommandDetailClose()
+  {
+    CurrentNote = null;
+    ShowDetail = false;
+  }
 
 }

--- a/LivingMessiahAdmin/Features/Sukkot/Notes/ListCard.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/Notes/ListCard.razor
@@ -1,0 +1,102 @@
+﻿
+<div class="row">
+	<div class="col-12">
+		<p class="text-black-50 float-end mt-1 mb-3">
+			<small>
+				All Rows: <b>@data!.Count()</b>;
+				Filtered Rows: <b>@filteredRows</b>
+			</small>
+		</p>
+	</div>
+</div>
+
+@foreach (var item in dataFilter!)
+{
+	<div class="card text-dark bg-light mb-3">
+
+		<div class="card-header">
+
+			<div class="container d-flex justify-content-between">
+				<p><b>@item.FirstName @item.FamilyName</b></p>
+				<p>
+					<a href="tel:@item.Phone" title="@item.PhoneNumber">@item.PhoneNumber</a>&nbsp;<i class="fa fa-phone"></i>
+				</p>
+				<p>
+					<a href="mailto:@item.EMail" title="@item.EMail">@item.EMail</a>&nbsp;<i class="far fa-envelope"></i>
+				</p>
+			</div>
+
+		</div>
+
+
+		@if (Filter == Enums.Filter.All)
+		{
+			<div class="row">
+				<div class="col-sm-6">
+
+					@if (!String.IsNullOrEmpty(item.AdminNotes))
+					{
+						<div class="card-body @Enums.Filter.Admin.CssBgColor">
+							<p class="card-text">@item.AdminNotes </p>
+						</div>
+					}
+				</div>
+				<div class="col-sm-6">
+					@if (!String.IsNullOrEmpty(item.UserNotes))
+					{
+						<div class="card-body @Enums.Filter.User.CssBgColor">
+							<p class="card-text">@item.UserNotes </p>
+						</div>
+					}
+				</div>
+			</div>
+		}
+		else
+		{
+			@if (!String.IsNullOrEmpty(item.AdminNotes))
+			{
+				<div class="card-body @Enums.Filter.Admin.CssBgColor">
+					<p class="card-text ms-5">@item.AdminNotes </p>
+				</div>
+			}
+
+			@if (!String.IsNullOrEmpty(item.UserNotes))
+			{
+				<div class="card-body @Enums.Filter.User.CssBgColor">
+					<p class="card-text ms-5">@item.UserNotes </p>
+				</div>
+			}
+		}
+	</div>
+}
+
+
+@code {
+	[Parameter, EditorRequired] public required Enums.Filter? Filter { get; set; }
+	[Parameter, EditorRequired] public List<NotesQuery>? data { get; set; }
+
+	private int filteredRows = 0;	
+
+	List<NotesQuery>? dataFilter = new List<NotesQuery>();
+	protected override void OnParametersSet()
+	{
+		switch (Filter!.Name)
+		{
+			case nameof(Enums.Filter.All):
+				dataFilter = data;
+        filteredRows = data!.Count();	
+				break;
+
+			case nameof(Enums.Filter.Admin):
+        dataFilter = data!.Where(w => w.HasAdminNotes).OrderBy(o => o.FirstName).ToList();
+        filteredRows = dataFilter.Count();		
+				break;
+
+			case nameof(Enums.Filter.User):
+        dataFilter = data!.Where(w => w.HasUserNotes).OrderBy(o => o.FirstName).ToList();
+				filteredRows = dataFilter.Count();
+				break;
+		}
+	}
+}
+

--- a/LivingMessiahAdmin/Features/Sukkot/Notes/NotesQuery.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Notes/NotesQuery.cs
@@ -1,0 +1,18 @@
+﻿using LivingMessiahAdmin.Helpers;
+
+namespace LivingMessiahAdmin.Features.Sukkot.Notes;
+
+public class NotesQuery
+{
+	public int Id { get; set; }
+	public string? FirstName { get; set; }
+	public string? FamilyName { get; set; }
+	public string? Phone { get; set; }
+	public string? EMail { get; set; }
+	public string? AdminNotes { get; set; }
+	public string? UserNotes { get; set; }
+
+	public bool HasAdminNotes => !string.IsNullOrEmpty(AdminNotes);
+	public bool HasUserNotes => !string.IsNullOrEmpty(UserNotes);
+	public string PhoneNumber => (Phone ?? "").PhoneNumber();
+}

--- a/LivingMessiahAdmin/Features/Sukkot/Notes/Typeahead.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/Notes/Typeahead.razor
@@ -1,0 +1,55 @@
+﻿@using System.Linq
+
+@inject ILogger<Typeahead>? Logger
+
+<div class="d-print-none">
+
+	<BlazoredTypeahead SearchMethod="SearchNotes"
+										 TValue="NotesQuery"
+										 TItem="NotesQuery"
+										 Value="CurrentNote"
+										 ValueChanged="SelectedResultChanged"
+										 ValueExpression="@(() => CurrentNote)"
+										 EnableDropDown="true"
+										 MaximumSuggestions="100"
+										 MinimumLength="2"
+										 placeholder="Search first name...">
+		<SelectedTemplate Context="contextNotes">
+			@contextNotes!.FirstName @contextNotes!.FamilyName [@contextNotes.Id]
+		</SelectedTemplate>
+		<HelpTemplate>Please enter at least 2 characters to perform a search on the first name</HelpTemplate>
+		<ResultTemplate Context="contextNotes">
+			@contextNotes.FirstName @contextNotes.FamilyName [@contextNotes.Id]
+		</ResultTemplate>
+	</BlazoredTypeahead>
+
+</div>
+
+@code {
+	[Parameter, EditorRequired] public List<NotesQuery>? data { get; set; }
+	[Parameter, EditorRequired] public required NotesQuery? SelectedNote { get; set; }
+	[Parameter] public EventCallback<NotesQuery> OnNotesQuerySelected { get; set; }
+
+	protected NotesQuery? CurrentNote { get; set; }
+
+	protected override void OnParametersSet()
+	{
+		CurrentNote = SelectedNote;
+	}
+
+	private async Task<IEnumerable<NotesQuery>> SearchNotes(string searchText)
+	{
+		return await Task.FromResult(data!
+		  .Where(x => x.FirstName!.ToLower().Contains(searchText.ToLower()))
+			.OrderBy(o => o.FirstName));
+	}
+
+	private void SelectedResultChanged(NotesQuery selectedNote)
+	{
+		Logger!.LogDebug("{Method}, {Message}"
+			, nameof(SelectedResultChanged)
+			, $"{selectedNote?.FirstName} {selectedNote?.FamilyName}, Id: {selectedNote?.Id}");
+		OnNotesQuerySelected.InvokeAsync(selectedNote);
+	}
+}
+

--- a/LivingMessiahAdmin/Helpers/StringExtensions.cs
+++ b/LivingMessiahAdmin/Helpers/StringExtensions.cs
@@ -46,4 +46,21 @@ public static class StringExtensions
 		if (string.IsNullOrEmpty(value)) return value;
 		return value.Length <= maxLength ? value : value.Substring(0, maxLength);
 	}
+
+	public static string PhoneNumber(this string value)
+	{
+		if (string.IsNullOrEmpty(value)) return string.Empty;
+		value = new System.Text.RegularExpressions.Regex(@"\D")
+				.Replace(value, string.Empty);
+		value = value.TrimStart('1');
+		if (value.Length == 7)
+			return Convert.ToInt64(value).ToString("###-####");
+		if (value.Length == 10)
+			return Convert.ToInt64(value).ToString("###-###-####");
+		if (value.Length > 10)
+			return Convert.ToInt64(value)
+					.ToString("###-###-#### " + new String('#', (value.Length - 10)));
+		return value;
+	}
+
 }

--- a/LivingMessiahAdmin/LivingMessiahAdmin.csproj
+++ b/LivingMessiahAdmin/LivingMessiahAdmin.csproj
@@ -10,6 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Features\Sukkot\RegistrationSteps\**" />
+    <Content Remove="Features\Sukkot\RegistrationSteps\**" />
+    <EmbeddedResource Remove="Features\Sukkot\RegistrationSteps\**" />
+    <None Remove="Features\Sukkot\RegistrationSteps\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\LivingMessiah.ServiceDefaults\LivingMessiah.ServiceDefaults.csproj" />
   </ItemGroup>
 
@@ -19,6 +26,7 @@
 		<PackageReference Include="Blazored.FluentValidation" Version="2.2.0" />
 		<PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
 		<PackageReference Include="Blazored.Toast" Version="4.2.1" />
+		<PackageReference Include="Blazored.Typeahead" Version="4.7.0" />
 		<PackageReference Include="Dapper" Version="2.1.66" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="9.0.6" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.6" />
@@ -36,9 +44,5 @@
 		<PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
 
 	</ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Features\Sukkot\RegistrationSteps\Enums\" />
-  </ItemGroup>
 
 </Project>

--- a/LivingMessiahAdmin/Program.cs
+++ b/LivingMessiahAdmin/Program.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using AccountEnum = LivingMessiahAdmin.Enums.Account;
 using LivingMessiahAdmin.Features.Database;
 using LivingMessiahAdmin.Features.Sukkot.ManageRegistration.Data;
+using LivingMessiahAdmin.Features.Sukkot.Notes.Data;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -58,6 +59,7 @@ try
 	//Services
 	builder.Services.AddDatabase();
 	builder.Services.AddSukkotData();
+	builder.Services.AddManageNotes();
 	//builder.Services.AddCalendar();
 	//builder.Services.AddFeastDayPlanner();
 

--- a/LivingMessiahAdmin/_Imports.razor
+++ b/LivingMessiahAdmin/_Imports.razor
@@ -12,6 +12,7 @@
 @using Blazored.Toast
 @using Blazored.Toast.Services
 @* @using Blazored.LocalStorage *@
+@using Blazored.Typeahead
 
 @using LivingMessiahAdmin.Features
 @using LivingMessiahAdmin.Enums


### PR DESCRIPTION

## Tasks Notes
- [x] Port Notes
- [x] Added Blazored.Typeahead
- [x] Added Data 📁 with Repository & ServiceCollectionExtensions 
- [ ] Make `DetailsCard.razor` use Markdown; maybe rename to `DetailsEditForm`
- [ ] Index.razor: commented out `<AuthorizeView Roles="@Roles.AdminOrSukkot">` will I need this???

### Screen Shots
#### Typeahead
![Details-ScreenShot-Typeahead](https://github.com/user-attachments/assets/e3b0d4d7-31d2-4046-bf94-9206f6a97396)

#### Filter
![Details-ScreenShot-Filter](https://github.com/user-attachments/assets/d5c77c97-1453-475e-bd93-47f5124834e4)


## Tasks HRA
- [x] Port HRA
![HRA-ScreenShot](https://github.com/user-attachments/assets/7e0dd641-5df9-4ecf-bb1a-db4e11a7c1c5)

## Tasks Refactor ManageRegistration
- [ ] 

Sukkot 📁
- ManageRegistration 📁
  - The items under this should be moved up to Sukkot and then ManageRegistration 📁 is deleted
  - Because the LMM Admin Web App is for

- MasterDetail 📁
  - This is the "Index.razor" of Sukkot 📁

## Tasks Other
- [ ] Create a RCL
- [x] Created an `Enums\Helper` folder for LivingMessiahAdmin.Features.Sukkot
  - [ ] Make LM `Year.cs` be like LMAdmin `CurrentYear.cs`
- [ ] Make LM `EntryFormHelper.cs` be like LMAdmin `EntryFormHelper.cs`
