### PR TITLE
Dashboard enhance, stripe webhook fix, Reg list crud, new EditDateList

### DIFF
--- a/LivingMessiahAdmin/Features/Sukkot/Dashboard/Data/DonationQuery.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Dashboard/Data/DonationQuery.cs
@@ -1,7 +1,0 @@
-﻿namespace LivingMessiahAdmin.Features.Sukkot.Dashboard.Data;
-
-public record DonationQuery(decimal Amount,	string? ReferenceId,	DateTime CreateDate);
- 
-/*
-	int RegistrationId, string? Notes,	string? Email,	string? CreatedBy,
- */

--- a/LivingMessiahAdmin/Features/Sukkot/Dashboard/Data/DonationTableQuery.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Dashboard/Data/DonationTableQuery.cs
@@ -1,0 +1,10 @@
+﻿namespace LivingMessiahAdmin.Features.Sukkot.Dashboard.Data;
+
+
+public record DonationTableQuery(
+	int Detail, 
+	decimal Amount, 
+	string Notes,	
+	string? ReferenceId,	
+	DateTime CreateDate
+	, string? CreatedBy);

--- a/LivingMessiahAdmin/Features/Sukkot/Dashboard/Data/StripeQuery.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Dashboard/Data/StripeQuery.cs
@@ -1,0 +1,12 @@
+namespace LivingMessiahAdmin.Features.Sukkot.Dashboard.Data;
+
+public class StripeQuery
+{
+	public int Id { get; set; }
+	public string Email { get; set; } = default!;
+	public int RegistrationId { get; set; }
+	public int ModificationCount { get; set; }
+	public DateTime LastModifiedDate { get; set; }
+	public string? FirstName { get; set; }
+	public string? FamilyName { get; set; }
+}

--- a/LivingMessiahAdmin/Features/Sukkot/Dashboard/DetailCard.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/Dashboard/DetailCard.razor
@@ -1,4 +1,6 @@
 ﻿@using LivingMessiahAdmin.Features.Sukkot.Constants
+@using LivingMessiahAdmin.Features.Sukkot.Enums
+
 <div class="card border border-3 border-dark-subtle mt-2">
 
   <div class="card-header text-center">
@@ -35,6 +37,19 @@
         Sukkot Receipt Url
       </a>
     </div>
+
+    @* Fee *@
+    <div class="my-1">
+      <div class="d-flex justify-content-center mb-2">
+        <span class="p-1"><b>Registration Fee</b>:&nbsp;</span>
+        <span class="p-1 bg-warning-subtle text-black">
+          @rec.RegistrationFee.CurrencyFormat
+        </span>
+      </div>
+    </div>
+
+    <DonationTable RegistrationId="rec.Id" />  
+
   }
 
   <div class="card-footer">
@@ -44,12 +59,25 @@
       </button>
   </div>
 
+
+
 </div>
 
 
 @code {
   [Parameter, EditorRequired] public required DetailCardRecord rec { get; set; }
   [Parameter] public EventCallback OnClose { get; set; }
+  string Fee = "___";
+
+
+  // protected override void OnParametersSet()
+  // {
+  //   //if (RegistrationFee.TryFromValue(rec.FeeEnumValue, out var registrationFee))
+  //   if (RegistrationFee.TryFromValue(rec.Adults, out var registrationFee))
+  //   {
+  //     Fee = registrationFee!.CurrencyFormat;
+  //   }
+  // }
 
   private void OnButtonClicked()
   {

--- a/LivingMessiahAdmin/Features/Sukkot/Dashboard/DetailCardRecord.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Dashboard/DetailCardRecord.cs
@@ -1,4 +1,10 @@
-﻿namespace LivingMessiahAdmin.Features.Sukkot.Dashboard;
+﻿using SukkotEnums = LivingMessiahAdmin.Features.Sukkot.Enums;
 
-public record DetailCardRecord(int Id, string FullName, string AdminNotes, string UserNotes);
+namespace LivingMessiahAdmin.Features.Sukkot.Dashboard;
 
+public record DetailCardRecord(
+int Id, 
+string FullName, 
+string AdminNotes, 
+string UserNotes,
+SukkotEnums.RegistrationFee RegistrationFee);  // int FeeEnumValue RegistrationFee

--- a/LivingMessiahAdmin/Features/Sukkot/Dashboard/DonationTable.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/Dashboard/DonationTable.razor
@@ -1,0 +1,54 @@
+@using LivingMessiahAdmin.Features.Sukkot.Dashboard.Data
+@using System.Globalization
+
+@inject ILogger<StripeTable>? Logger
+@inject IToastService? Toast
+@inject IRepository? db
+
+<LoadingComponent IsLoading="DonationTableList == null" TurnSpinnerOff=TurnSpinnerOff>
+
+  <div class="mt-2 mx-2">
+    <h4 class="text-center bg-primary-subtle pt-2 pb-0 mb-0">Donation</h4>
+    <TableTemplate Items="DonationTableList" HeaderCSS="@HeaderCSS">
+      <TableHeader>
+        <th>#</th>
+        <th>Amount</th>
+        <th>Notes</th>
+        <th>Reference Id</th>
+        <th>Created</th>
+        <th>Created By</th>
+      </TableHeader>
+      <RowTemplate>
+        <td>@context.Detail</td>
+        <td>@context.Amount.ToString("C0", CultureInfo.GetCultureInfo("en-US"))</td>
+        <td>@context.Notes</td>
+        <td>@context.ReferenceId</td>
+        <td>@context.CreateDate.ToString("g")</td>
+        <td>@context.CreatedBy</td>
+      </RowTemplate>
+    </TableTemplate>
+  </div>
+</LoadingComponent>
+
+@code {
+  [Parameter, EditorRequired] public int RegistrationId { get; set; }
+  protected string? HeaderCSS = "table table-primary table-hover";
+
+  bool TurnSpinnerOff = false;
+  public List<DonationTableQuery>? DonationTableList { get; set; }
+  protected override async Task OnParametersSetAsync()
+  {
+    Logger!.LogDebug("{Method}", nameof(OnParametersSetAsync));
+    try
+    {
+      DonationTableList = await db!.GetAllDonations(RegistrationId);
+    }
+    catch (Exception ex)
+    {
+      Logger!.LogError(ex, "{Method}", nameof(OnParametersSetAsync));
+      Toast!.ShowError($"{Global.ToastShowError} | {nameof(OnParametersSetAsync)}");
+    }
+    TurnSpinnerOff = true;
+  }
+
+}

--- a/LivingMessiahAdmin/Features/Sukkot/Dashboard/Grid.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/Dashboard/Grid.razor
@@ -3,6 +3,7 @@
 @using Microsoft.AspNetCore.Components.QuickGrid
 @using FilterEnums = LivingMessiahAdmin.Features.Sukkot.Dashboard.Enums.Filter
 @using ShowColumnEnums = LivingMessiahAdmin.Features.Sukkot.Dashboard.Enums.ShowColumn
+@using SukkotEnumsHelpers = LivingMessiahAdmin.Features.Sukkot.Enums.Helpers
 
 @inject ILogger<Grid>? Logger
 @inject IRepository? db;
@@ -175,7 +176,12 @@
     if (item is not null)
     {
       SelectedItem = item;
-      DetailCardRecord = new DetailCardRecord(item.Id, item!.FullName ?? "None", item!.AdminNotes ?? "", item!.Notes ?? "");
+      
+      DetailCardRecord = new DetailCardRecord(
+        item.Id, item!.FullName ?? "None"
+        , item!.AdminNotes ?? ""
+        , item!.Notes ?? ""
+        , SukkotEnumsHelpers.RegistrationFeeHelper.AdultsToRegistrationFee(item.Adults));
     }
   }
 
@@ -206,7 +212,7 @@
   }
 
   // Initial default setting done by using `Bitwise Operator` `|` (OR).
-  protected int Bitwise = ShowColumnEnums.Email.Value | ShowColumnEnums.People.Value | ShowColumnEnums.Attendance.Value;
+  protected int Bitwise = ShowColumnEnums.Email.Value | ShowColumnEnums.People.Value | ShowColumnEnums.Paid.Value | ShowColumnEnums.Attendance.Value;
 
   private void ReturnedShowColumn(int bitwise)
   {

--- a/LivingMessiahAdmin/Features/Sukkot/Dashboard/Index.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/Dashboard/Index.razor
@@ -12,6 +12,7 @@
   <Authorized>
     <PageHeaderMenubar MenuBarEnum=MenuBar.Dashboard />
     <Grid />
+    <StripeTable />
   </Authorized>
   <NotAuthorized>
     <LoginRedirectCard Nav="Nav.SukkotDashboard" ReturnUrl=@Nav.SukkotDashboard.Index />

--- a/LivingMessiahAdmin/Features/Sukkot/Dashboard/StripeTable.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/Dashboard/StripeTable.razor
@@ -1,0 +1,54 @@
+@using LivingMessiahAdmin.Features.Sukkot.Dashboard.Data
+
+@inject ILogger<StripeTable>? Logger
+@inject IToastService? Toast
+@inject IRepository? db
+
+<LoadingComponent IsLoading="StripeQuerys == null" TurnSpinnerOff=TurnSpinnerOff>
+
+<div class="mt-4">
+	<TableTemplate Items="StripeQuerys" HeaderCSS="@HeaderCSS">
+		<TableHeader>
+			<th>Id</th>
+			<th>Email</th>
+			<th>Registration Id</th>
+			<th>Modification Count</th>
+			<th>Last Modified</th>
+			<th>First Name</th>
+			<th>Family Name</th>
+		</TableHeader>
+		<RowTemplate>
+			<td>@context.Id</td>
+			<td>@context.Email</td>
+			<td>@context.RegistrationId</td>
+			<td>@context.ModificationCount</td>
+			<td>@context.LastModifiedDate.ToString("g")</td>
+			<td>@context.FirstName</td>
+			<td>@context.FamilyName</td>
+		</RowTemplate>
+	</TableTemplate>
+</div>
+</LoadingComponent>
+
+@code {
+	//[Parameter, EditorRequired] public List<StripeQuery>? ParamStripeList { get; set; }
+	protected string? HeaderCSS = "table table-primary table-hover";
+
+	bool TurnSpinnerOff = false;
+	public List<StripeQuery>? StripeQuerys { get; set; }
+	protected override async Task OnInitializedAsync()
+	{
+		Logger!.LogDebug("{Method}", nameof(OnInitializedAsync));
+		try
+		{
+			StripeQuerys = await db!.GetAllStripe();
+		}
+		catch (Exception ex)
+		{
+			Logger!.LogError(ex, "{Method}", nameof(OnInitializedAsync));
+			Toast!.ShowError($"{Global.ToastShowError} | {nameof(OnInitializedAsync)}");
+		}
+		TurnSpinnerOff = true;
+	}
+
+}

--- a/LivingMessiahAdmin/Features/Sukkot/Enums/Helpers/RegistrationFeeHelper.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Enums/Helpers/RegistrationFeeHelper.cs
@@ -1,0 +1,9 @@
+﻿namespace LivingMessiahAdmin.Features.Sukkot.Enums.Helpers;
+
+public class RegistrationFeeHelper
+{
+	public static RegistrationFee AdultsToRegistrationFee(int adults)
+	{
+		return adults > 1 ? RegistrationFee.Family : RegistrationFee.Single;
+	}
+}

--- a/LivingMessiahAdmin/Features/Sukkot/Enums/RegistrationFee.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Enums/RegistrationFee.cs
@@ -43,11 +43,3 @@ public abstract class RegistrationFee : SmartEnum<RegistrationFee>
 	#endregion
 
 }
-
-public class RegistrationFeeHelper
-{
-	public static RegistrationFee AdultsToRegistrationFee(int adults)
-	{
-		return adults > 1 ? RegistrationFee.Family : RegistrationFee.Single;
-	}
-}

--- a/LivingMessiahAdmin/Features/Sukkot/Home/Data/DonationQuery.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Home/Data/DonationQuery.cs
@@ -1,7 +1,7 @@
 ﻿namespace LivingMessiahAdmin.Features.Sukkot.Home.Data;
 
+/* 
+- Called only by `Report.razor` `OnParametersSetAsync`
+- LivingMessiahAdmin\Features\Sukkot\Home\RegistrationDetail\Report.razor
+*/
 public record DonationQuery(decimal Amount,	string? ReferenceId,	DateTime CreateDate);
-
-/*
-	int RegistrationId, string? Notes,	string? Email,	string? CreatedBy,
- */

--- a/LivingMessiahAdmin/Features/Sukkot/Home/Data/ServiceCollectionExtensions.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Home/Data/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿//using FluentValidation;
+﻿using FluentValidation;
 
 namespace LivingMessiahAdmin.Features.Sukkot.Home.Data;
 
@@ -8,8 +8,8 @@ public static class ServiceCollectionExtensions
 	{
 		services
 			//.AddTransient<ISecurityHelper, SecurityHelper>()
-			.AddTransient<IRepository, Repository>();
-			//.AddTransient<IValidator<NormalUser.EntryFormVM>, NormalUser.EntryFormVMValidator>();
+			.AddTransient<IRepository, Repository>()
+			.AddTransient<IValidator<Registrant.FormVM>, Registrant.FormVMValidator>();
 		return services;
 	}
 }

--- a/LivingMessiahAdmin/Features/Sukkot/Home/Index.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/Home/Index.razor
@@ -18,7 +18,7 @@
 
 <AuthorizeView Policy=@RoleGroup.Sukkot>
   <Authorized>
-    
+
     @if (VisibleComponent == Enums.VisibleComponent.RegistrationList)
     {
       <PageHeaderMenubar MenuBarEnum=MenuBar.Home ShowPrintButton=true />
@@ -44,7 +44,12 @@
 
       @if (VisibleComponent == Enums.VisibleComponent.Registrant)
       {
-        <RegistrantForm />
+        <div class="card mt-0 mb-3 @Step.Registration.CardBodyCSS">
+          <div class="card-body @Step.Registration.CardBodyCSS">
+            @*  OnAddCompleted="ReturnedRegistrationAddCompleted"  *@
+            <RegistrantForm Email="@Email" Id="@Id"  CurrentStep="Step.Registration"/>
+          </div>
+        </div>
       }
       else
       {
@@ -83,6 +88,7 @@
 
 
   int Id { get; set; } = 0;
+  string? Email { get; set; } = null;
   DetailPageHeaderVM? DetailPageHeaderVM;
 
   protected override async Task OnInitializedAsync()
@@ -124,11 +130,30 @@
     }
     else
     {
-      if (args.Crud == Crud.Edit)
+      if (args.Crud == Crud.AddRegistration)
       {
+        Id = 0;
+        Email = args.EMail;
         VisibleComponent = Enums.VisibleComponent.Registrant;
         DetailPageHeaderVM = new DetailPageHeaderVM(args.Crud.Name, args.FullName);
       }
+      else
+      {
+        if (args.Crud == Crud.Edit)
+        {
+          Id = args.Id;
+          Email = args.EMail;
+          VisibleComponent = Enums.VisibleComponent.Registrant;
+          DetailPageHeaderVM = new DetailPageHeaderVM(args.Crud.Name, args.FullName);
+        }
+         else
+         {
+          Toast!.ShowWarning($"Unknown Crud Action: {args.Crud.Name}");
+         //  if (args.Crud == Crud.Donation)  { }
+         //  if (args.Crud == Crud.DeleteRegistration) { }
+         }
+      } 
+
     }
   }
 }

--- a/LivingMessiahAdmin/Features/Sukkot/Home/Registrant/AttendanceEditDateList.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/Home/Registrant/AttendanceEditDateList.razor
@@ -1,0 +1,60 @@
+﻿@using LivingMessiahAdmin.Features.Sukkot.Enums;
+@using Microsoft.AspNetCore.Components
+
+<div class="mt-0">
+	<ul style="list-style-type:none; padding-inline-start: 0px">
+		@foreach (var item in AttendanceDate.List.Where(w => w.Value != AttendanceDate.None).OrderBy(o => o.Value).ToList())
+		{
+			<li class="font-monospace @GetCSS(item.Date)">
+				<input type="checkbox"
+					   checked="@IsSelected(item.Date)"
+					   @onchange="() => ToggleDate(item.Date)" />
+				<span>@item.Title</span>
+			</li>
+		}
+	</ul>
+</div>
+
+@code {
+	[Parameter, EditorRequired] public DateTime[]? SelectedDates { get; set; }
+	[Parameter] public EventCallback<DateTime[]> SelectedDatesChanged { get; set; }
+
+	private bool IsSelected(DateTime date) =>
+		SelectedDates != null && Array.Exists(SelectedDates, d => d == date);
+
+	private async Task ToggleDate(DateTime date)
+	{
+		if (SelectedDates == null)
+		{
+			SelectedDates = new[] { date };
+		}
+		else if (IsSelected(date))
+		{
+			SelectedDates = SelectedDates.Where(d => d != date).ToArray();
+		}
+		else
+		{
+			SelectedDates = SelectedDates.Append(date).ToArray();
+		}
+		await SelectedDatesChanged.InvokeAsync(SelectedDates);
+	}
+
+	private string GetCSS(DateTime date)
+	{
+		if (SelectedDates is null)
+		{
+			return "";
+		}
+		else
+		{
+			if (Array.Exists(SelectedDates, d => d == date))
+			{
+				return "fw-bold text-primary";
+			}
+			else
+			{
+				return "";
+			}
+		}
+	}
+}

--- a/LivingMessiahAdmin/Features/Sukkot/Home/Registrant/DTO.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Home/Registrant/DTO.cs
@@ -1,0 +1,24 @@
+﻿namespace LivingMessiahAdmin.Features.Sukkot.Home.Registrant;
+
+public record DTO
+{
+	public int Id { get; set; }
+	public string? FamilyName { get; set; }
+	public string? FirstName { get; set; }
+	public string? SpouseName { get; set; }
+	public string? OtherNames { get; set; }
+	public string? EMail { get; set; }
+	public string? Phone { get; set; }
+
+	public int Adults { get; set; }
+	public int ChildBig { get; set; }
+	public int ChildSmall { get; set; }
+	public int FeeEnumValue { get; set; }
+
+	public int StatusId { get; set; } // ToDo Convert to StepId
+
+	public int AttendanceBitwise { get; set; }
+
+	public string? Notes { get; set; }
+	public string? Avatar { get; set; }
+}

--- a/LivingMessiahAdmin/Features/Sukkot/Home/Registrant/EntryFormAddOrEditRecord.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Home/Registrant/EntryFormAddOrEditRecord.cs
@@ -1,0 +1,4 @@
+﻿namespace LivingMessiahAdmin.Features.Sukkot.Home.Registrant;
+
+public record EntryFormAddOrEditRecord(bool IsAdd, string Title, string Title2, string SubmitButtonText);
+

--- a/LivingMessiahAdmin/Features/Sukkot/Home/Registrant/FormVM.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Home/Registrant/FormVM.cs
@@ -16,15 +16,14 @@ public class FormVM
 	public int ChildBig { get; set; }
 	public int ChildSmall { get; set; }
 
-	public int StatusId { get; set; } // The ManageRegistration!EntryForm needs this
-	public Step? Status { get; set; }  // Status? Status
+	public int StepId { get; set; } // The ManageRegistration!EntryForm needs this
+	public Step? Step { get; set; }
 
 	public int AttendanceBitwise { get; set; } // does the VM need this?
 	public DateTime[]? AttendanceDateList { get; set; }
 	public DateTime[]? AttendanceDateList2ndMonth { get; set; }
 
 	public string? Notes { get; set; }
-	public string? AdminNotes { get; set; }
-	public bool DidNotAttend { get; set; }
-	public decimal LmmDonation { get; set; }
+	//public string? AdminNotes { get; set; }
+	//public bool DidNotAttend { get; set; }
 }

--- a/LivingMessiahAdmin/Features/Sukkot/Home/Registrant/FormVMValidator.cs
+++ b/LivingMessiahAdmin/Features/Sukkot/Home/Registrant/FormVMValidator.cs
@@ -1,0 +1,31 @@
+﻿using FluentValidation;
+
+namespace LivingMessiahAdmin.Features.Sukkot.Home.Registrant;
+
+public class FormVMValidator : AbstractValidator<FormVM>
+{
+	public FormVMValidator()
+	{
+		RuleFor(p => p.FirstName)
+			.NotEmpty().WithMessage("You must enter your first name")
+			.MaximumLength(50).WithMessage("First name cannot be longer than 50 characters");
+
+		RuleFor(p => p.FamilyName)
+					.NotEmpty().WithMessage("You must enter your last name")
+					.MaximumLength(75).WithMessage("Last name cannot be longer than 75 characters");
+
+		RuleFor(s => s.SpouseName).Length(1, 50).When(s => !string.IsNullOrEmpty(s.SpouseName));
+
+		RuleFor(p => p.OtherNames)
+				.MaximumLength(255).WithMessage("OtherNames name cannot be longer than 255 characters");
+
+		RuleFor(p => p.Phone)
+				.MaximumLength(15).WithMessage("Phone number cannot be longer than 15 characters");
+
+		RuleFor(p => p.Adults)
+				.NotNull().WithMessage("You must enter the number of adults")
+				.GreaterThanOrEqualTo(1).WithMessage("Number of adults must be 1 or greater")
+				.LessThan(20).WithMessage("Number of adults cannot be greater than 20");
+	}
+}
+

--- a/LivingMessiahAdmin/Features/Sukkot/Home/Registrant/RegistrantForm.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/Home/Registrant/RegistrantForm.razor
@@ -1,56 +1,302 @@
-﻿@using LivingMessiahAdmin.Features.Sukkot.Home.Registrant.Constants
+﻿@using Blazored.FluentValidation
+@using LivingMessiahAdmin.Features.Sukkot.Home.Registrant.Constants
+@using LivingMessiahAdmin.Features.Sukkot.Home.Data
+@using LivingMessiahAdmin.Features.Sukkot.Home.RegistrationDetail
+
+@using SukkotEnums = LivingMessiahAdmin.Features.Sukkot.Enums
+@using SukkotEnumsHelpers = LivingMessiahAdmin.Features.Sukkot.Enums.Helpers
 
 @inject ILogger<RegistrantForm>? Logger
 @inject IToastService? Toast
+@inject IRepository? db
 
-<div class="alert alert-warning text-center fs-4" role="alert">
-  ToDo: Add EditForm which looks just like the one in LivingMessiah web app
-  <br />
-  Inside: <b>@nameof(RegistrantForm)</b>
-</div>
+@* Hack: I'm using LoadingComponent because AddOrEditState (a record) can't be null  *@
 
+<LoadingComponent IsLoading="AddOrEditState == null" TurnSpinnerOff=TurnSpinnerOff>
+  <h4>@AddOrEditState!.Title <span class="float-end"><sup><i>@AddOrEditState!.Title2</i></sup></span></h4>
 
-<div class="row">
-  <div class="col-sm-6">
-    <div class="my-2">
+  <EditForm Model="@VM" OnValidSubmit="@SubmitValidForm">
+    <FluentValidationValidator @ref="_fluentValidationValidator" DisableAssemblyScanning="@true" />
+    <ValidationSummary />
 
-      <button type="submit" class="@SaveButton.Color">
-        <i class="@SaveButton.Icon"></i> @Enums.FormMode.Add.SubmitText
-        @* @Enums.FormMode.Update.SubmitText *@
+    <fieldset class="mt-3">
+      <legend class="text-primary">Contact Information</legend>
 
-      </button>
+      <div class="row">
 
-      @*
-				Cancel button has to be a div (ie not a button) thereby not triggering validation which is what I want
-				[Blazor Modal Form Validation: You have to click the cancel button twice to close the modal when you delete a form field](https://stackoverflow.com/a/67737357/41106)
-				*@
-      <div @onclick="@(e => CancelActionHandler())" class="@Constants.CancelButton.Color">
-        <i class="@Constants.CancelButton.Icon"></i> @CancelButton.Text
+        <div class="col-sm-4">
+          <div class="form-floating mb-3">
+            <InputText id="lastName" class="form-control" @bind-Value="VM!.FamilyName" placeholder="Ben Levi" />
+            <label for="familyName" class="form-label">Last Name</label>
+            <ValidationMessage For="@(() => VM.FamilyName)" />
+          </div>
+        </div>
+
+        <div class="col-sm-4">
+          <div class="form-floating mb-3">
+            <InputText id="firstName" class="form-control" @bind-Value="VM.FirstName" placeholder="Moshe" />
+            <label for="firstName" class="form-label">First Name</label>
+            <ValidationMessage For="@(() => VM.FirstName)" />
+          </div>
+        </div>
+
+        <div class="col-sm-4">
+          <div class="form-floating mb-3">
+            <InputText id="spouseName" class="form-control" @bind-Value="VM.SpouseName" placeholder="Spousal Unit" />
+            <label for="spouseName" class="form-label">Spouses Name</label>
+            <ValidationMessage For="@(() => VM.SpouseName)" />
+          </div>
+        </div>
 
       </div>
 
-    </div>
-  </div>
-  <div class="col-sm-6"></div>
-</div>
+
+      <div class="row">
+
+        <div class="col-sm-6">
+          <div class="form-floating mb-3">
+            <InputText id="otherNames" class="form-control" @bind-Value="VM.OtherNames" placeholder="other names" />
+            <label for="otherNames" class="form-label">Other Names</label>
+            <ValidationMessage For="@(() => VM.OtherNames)" />
+          </div>
+        </div>
+
+        <div class="col-sm-6">
+          <div class="form-floating mb-3">
+            <InputText id="phone" class="form-control" @bind-Value="VM.Phone" placeholder="phone (optional)" />
+            <label for="phone" class="form-label">Phone (optional)</label>
+            <ValidationMessage For="@(() => VM.Phone)" />
+          </div>
+        </div>
+
+        @*<div class="col-sm-4">
+				<div class="form-floating mb-3">
+				<label for="avatar">Avatar</label>
+				<InputText id="avatar" class="form-control" @bind-Value="VM.Avatar" placeholder="picture (optional)" />
+				<ValidationMessage For="@(() => VM.Avatar)" />
+				</div>
+				</div>*@
+
+      </div>
+    </fieldset>
+
+    <fieldset class="mt-3">
+      <legend class="text-primary">Attendance</legend>
+
+      <div class="row mt-n2">
+        <div class="col-12">
+          <div class="card bg-light mb-3">
+            <div class="card-body">
+              <p class="card-text">
+                To help us with planning, select what days will you be attending.  Please select <u>ALL</u> the dates, not just the beginning and ending.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <p class="text-center">
+        Date Range: @DateRangeAttendance.Range.Min.ToShortDateString() - @DateRangeAttendance.Range.Max.ToShortDateString()
+      </p>
+
+      <div class="d-flex justify-content-center">
+        <div class="mx-3">
+          <AttendanceEditDateList @bind-SelectedDates="VM.AttendanceDateList" />
+        </div>
+      </div>
+
+    </fieldset>
+
+    <fieldset class="mt-3">
+      <legend class="text-primary">People Count <small class="text-black-50">Step: @(CurrentStep?.Name ?? "???")</small></legend>
+
+      <div class="row mt-n2">
+        <div class="col-sm-4">
+
+          <div class="form-floating mb-3">
+
+            <InputNumber id="adults"
+                         class="form-control"
+                         @bind-Value="VM.Adults"
+                         placeholder="Adult Count"
+                         disabled="@(CurrentStep?.Value == SukkotEnums.Step.Complete.Value)" />
+            <label for="adults" class="form-label">Adults</label>
+            <ValidationMessage For="@(() => VM.Adults)" />
+
+          </div>
+        </div>
+
+        <div class="col-sm-4">
+          <div class="form-floating mb-3">
+            <InputNumber id="childBig" class="form-control" @bind-Value="VM.ChildBig" placeholder="Child Count Big" />
+            <label for="childBig" class="form-label">Child <sup>big</sup></label>
+            <ValidationMessage For="@(() => VM.ChildBig)" />
+          </div>
+        </div>
+
+        <div class="col-sm-4">
+          <div class="form-floating mb-3">
+            <InputNumber id="childSmall" class="form-control" @bind-Value="VM.ChildSmall" placeholder="Child Count Small" />
+            <label for="childSmall" class="form-label">Child <sup>small</sup></label>
+            <ValidationMessage For="@(() => VM.ChildSmall)" />
+          </div>
+        </div>
+
+      </div>
+    </fieldset>
+
+    <fieldset class="mt-3">
+      <legend class="text-primary">Other (optional)</legend>
+      <div class="row mt-n2">
+        <div class="col-12">
+          <div class="form-floating mb-3">
+            <InputTextArea id="notes" class="form-control" @bind-Value="VM.Notes" placeholder="Notes" />
+            <label for="notes" class="form-label"><small>Notes / Emergency Contact / Fellowship Attending</small></label>
+            <p class="mt-1">
+              Please include emergency contact.  If not attending Living Messiah, please include name of fellowship or congregation currently attending, if none list a personal reference.
+            </p>
+            <ValidationMessage For="@(() => VM.Notes)" />
+
+          </div>
+        </div>
+      </div>
+    </fieldset>
+
+    <button type="submit" class="btn btn-primary btn-lg mt-2">
+      <i class="fas fa-save"></i> @AddOrEditState!.SubmitButtonText
+    </button>
+
+  </EditForm>
+
+</LoadingComponent>
+
 
 @code {
+  [Parameter, EditorRequired] public int Id { get; set; }
+  [Parameter, EditorRequired] public string? Email { get; set; }
+  [Parameter, EditorRequired] public SukkotEnums.Step? CurrentStep { get; set; }
 
-  protected void HandleValidSubmit()
+  protected FormVM? VM { get; set; } = new FormVM();
+
+  private FluentValidationValidator? _fluentValidationValidator;
+  public SukkotEnums.DateRangeType DateRangeAttendance { get; set; } = SukkotEnums.DateRangeType.Attendance;
+
+  bool TurnSpinnerOff = false;
+  EntryFormAddOrEditRecord? AddOrEditState;
+  private int Id2;
+
+  protected override async Task OnInitializedAsync()
   {
-    Logger!.LogDebug("{Method} {FormMode}", nameof(HandleValidSubmit), "FormMode is ???");
+    Id2 = Id; // Id ?? 0;
+    Logger!.LogDebug("{Method}, Action: {Action} Id2:{id}; Email: {Email}"
+      , nameof(OnInitializedAsync), Id2 == 0 ? "Add" : "Update", Id2, Email);
 
-    //Dispatcher!.Dispatch(new AddOrEdit_Action(State!.Value.FormVM!, State!.Value.FormMode!));
-    //Dispatcher!.Dispatch(new MasterDetail.GetAll_Action());
-    //Dispatcher!.Dispatch(new ParentState.Set_PageHeader_For_Index_Action(ManageRegistration.Constants.GetPageHeaderForIndexVM()));
+    try
+    {
+      if (Id2 == 0)
+      {
+        VM = new FormVM();
+        VM.EMail = Email;
+        AddOrEditState = new EntryFormAddOrEditRecord(IsAdd: true, "Add - Registration", Email!, "Save");
+      }
+      else
+      {
+        AddOrEditState = new EntryFormAddOrEditRecord(IsAdd: false, "Edit - Registration", $"{Email}", "Update");
+        VM = await GetById(Id2);
+      }
+    }
+
+    catch (Exception ex)
+    {
+      Logger!.LogError(ex, "{Method}", nameof(OnInitializedAsync));
+      Toast!.ShowError(Global.ToastShowError);
+    }
+    TurnSpinnerOff = true;
+  }
+
+  private async Task<FormVM> GetById(int id)
+  {
+    Logger!.LogInformation("{Method} id: {id}", nameof(GetById), id);
+
+    FormVM? VM = new();
+    try
+    {
+      VM = await db!.Get(id);  
+      VM.Step = SukkotEnums.Step.FromValue(VM.StepId);
+      var (week1, week2) = SukkotEnumsHelpers.EntryFormHelper.GetAttendanceDatesArray(VM.AttendanceBitwise);
+      VM.AttendanceDateList = week1;
+      VM.AttendanceDateList2ndMonth = week2;
+
+    }
+    catch (Exception ex)
+    {
+      Logger!.LogError(ex, "{Method}", nameof(GetById));
+      Toast!.ShowError(Global.ToastShowError);
+    }
+    return VM;
 
   }
 
-
-  void CancelActionHandler()
+  protected async Task SubmitValidForm()
   {
-    Logger!.LogDebug("{Method}", nameof(CancelActionHandler));
-    Toast!.ShowWarning("Cancel button clicked - no action taken");
-    //Dispatcher!.Dispatch(new ParentState.Set_PageHeader_For_Index_Action(ManageRegistration.Constants.GetPageHeaderForIndexVM()));
+    Logger!.LogDebug("{Method}, Action: {Action} Id2:{id}", nameof(SubmitValidForm), Id2 == 0 ? "Add" : "Update", Id2);
+    try
+    {
+      if (AddOrEditState!.IsAdd)
+      {
+        VM!.Step = SukkotEnums.Step.Payment;
+        VM.AttendanceBitwise = SukkotEnumsHelpers.EntryFormHelper.GetDaysBitwise(
+            VM.AttendanceDateList!, VM.AttendanceDateList2ndMonth!, SukkotEnums.DateRangeType.Attendance);
+        var (newId, sprocReturnValue, returnMsg) = await db!.CreateRegistration(DTO_From_VM_To_DB(VM));
+        if (newId == 0)
+        {
+          Logger!.LogWarning("{Method} {Message} {Sql} {ReturnValue} {ReturnMsg}"
+          , nameof(SubmitValidForm), "Registration NOT CREATED! newId==0", nameof(db.CreateRegistration), sprocReturnValue, returnMsg);
+          Toast!.ShowError("Error creating registration");
+          return;
+        }
+        else
+        {
+          Logger!.LogInformation("{Method} Registration created! Id2:{id}", nameof(SubmitValidForm), Id2);
+          Toast!.ShowInfo($"Registration Added!");
+        }
+      }
+      else
+      {
+        var (rowsAffected, sprocReturnValue, returnMsg) = await db!.UpdateRegistration(DTO_From_VM_To_DB(VM!));
+        Logger!.LogInformation("{Method}; Registration updated!", nameof(SubmitValidForm));
+        Toast!.ShowInfo($"Registration updated!");
+      }
+    }
+    catch (Exception ex)
+    {
+      Logger!.LogError(ex, "{Method} {Action}", nameof(SubmitValidForm), AddOrEditState!.Title);
+      Toast!.ShowError(Global.ToastShowError);
+    }
   }
+
+  private DTO DTO_From_VM_To_DB(FormVM vm)
+  {
+    DTO poco = new DTO
+    {
+      Id = vm.Id,
+      FamilyName = vm.FamilyName,
+      FirstName = vm.FirstName,
+      SpouseName = vm.SpouseName?.Trim() ?? string.Empty,
+      OtherNames = vm.OtherNames,
+      EMail = vm.EMail,
+      Phone = vm.Phone,
+      Adults = vm.Adults,
+      ChildBig = vm.ChildBig,
+      ChildSmall = vm.ChildSmall,
+      FeeEnumValue = SukkotEnumsHelpers.RegistrationFeeHelper.AdultsToRegistrationFee(vm.Adults),
+      StatusId = vm.Step, //  StepId = vm.Step!.Value,
+      AttendanceBitwise = SukkotEnumsHelpers.EntryFormHelper.GetDaysBitwise(
+        vm.AttendanceDateList!, vm.AttendanceDateList2ndMonth!, SukkotEnums.DateRangeType.Attendance),
+      Notes = LivingMessiahAdmin.Data.Helper.Scrub(vm.Notes),
+      Avatar = string.Empty
+    };
+    return poco;
+  }
+
 }

--- a/LivingMessiahAdmin/Features/Sukkot/Home/RegistrationDetail/AttendanceDateList.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/Home/RegistrationDetail/AttendanceDateList.razor
@@ -1,6 +1,6 @@
 ﻿@using LivingMessiahAdmin.Features.Sukkot.Enums;
 
-<div class="mt-3">
+<div class="mt-0">
 	<ul style="list-style-type:none; padding-inline-start: 0px">
 		@foreach (var item in AttendanceDate.List.Where(w => w.Value != AttendanceDate.None).OrderBy(o => o.Value).ToList())
 		{

--- a/LivingMessiahAdmin/Features/Sukkot/Home/RegistrationList/ActionButtonGroup.razor
+++ b/LivingMessiahAdmin/Features/Sukkot/Home/RegistrationList/ActionButtonGroup.razor
@@ -55,12 +55,10 @@ else
 		switch (args.Crud.Name)
 		{
 			case nameof(Crud.AddRegistration):
-				Toast!.ShowWarning($"{Crud.AddRegistration.Name} is not yet implemented; Inside{nameof(ActionButtonGroup)}");
 				await OnCrudActionSelected.InvokeAsync(args);
 				break;
 
 			case nameof(Crud.Edit):
-				Toast!.ShowWarning($"{Crud.Edit.Name} is not yet implemented; Inside{nameof(ActionButtonGroup)}");
 				await OnCrudActionSelected.InvokeAsync(args);
 				break;
 


### PR DESCRIPTION
# Tasks

### Tasks Give Dashboard more detail info

- [x] Do better Details for DataGrid, Stripe entries, etc.
- [x] Added `DonationTable.razor` and all it's database fixings

#### Dashboard showing a detail record
![Screen-Shot-Dashboard](https://github.com/user-attachments/assets/a5b4f8c0-2923-481b-bc93-1beb1c1f71bb)


### Tasks Stripe Webhook not working
- [x] Bug. the Stripe errors bad signature in header: 
  - [x] Fixed. The Azure Environment Settings had `StripeWebhookSecret` but needed to be `Stripe:WebhookSecret`
- [x] Add `StripeTable.razor` and database view for Stripe table, and all the database fixings in the Admin project (Features\Sukkot\Dashboard\). See Prompt below
- If webhook doesn't work (or the user canceled from the Stripe handoff) it's will show up below .

#### How it's called from `Dashboard` 📁  `Index.razor`

![StripeTable](https://github.com/user-attachments/assets/24242c0a-d8a5-423e-85a5-fb894ee41fd9)

### Tasks Edit and Add to Registration List
- [x] Hooked up Crud Actions to `RegistrationList` 📁 `Index.razor`

- [x] Ported Registration Form stuff from `LivingMessiah.csproj` Features\Sukkot\NormalUser\ to `LivingMessiahAdmin.csproj`
  - [x] Created `AttendanceEditDateList.razor` which was copied from `AttendanceDateList.razor` (see prompt)

#### Objects ported

![Port-Registration-Form-stuff](https://github.com/user-attachments/assets/084eea8c-7aea-47cb-9b4c-9966b618ae13)

#### Code changes `AttendanceEditDateList.razor` 
![AttendanceEditDateList-changes-from-read-only](https://github.com/user-attachments/assets/26129964-cde9-4c67-b4f3-33eab1a444ca)

- has no dependency on `SyncFusion.Calendar`
- greatly simplified the code in `RegistrationForm.razor` 
  - no concerns for media query or second week stuff
