### PR TITLE
Polish PWA Home PDF and Sukkot card UI.

### DIFF
--- a/PWA/Features/Home/Shabbat/Teaching/Archives/Grid.razor
+++ b/PWA/Features/Home/Shabbat/Teaching/Archives/Grid.razor
@@ -24,75 +24,85 @@
 	<div class="fs-5 text-center mb-2">List of Previous Teachings</div>
 
 	<div class="d-flex justify-content-center">
-		<div>
+		<QuickGrid Items="@filteredItems"
+							 TGridItem="Projection"
+							 Pagination="@pagination">
 
-			<QuickGrid Items="@filteredItems"
-								 TGridItem="Projection"
-								 Pagination="@pagination">
+			<TemplateColumn Sortable="false">
+				<HeaderTemplate>
+					<span class="@headerTemplate">Teaching Only <i class="fas fa-file-download ms-1"></i></span>
+				</HeaderTemplate>
+				<ChildContent>
+					<GridAnchor Href="@context.TeachingHref"
+											Text="@context.TorahAbrv"
+											Title="@context.TeachingPdfFile"
+											Bold="true" />
+				</ChildContent>
+			</TemplateColumn>
 
-				<TemplateColumn Sortable="false">
-					<HeaderTemplate>
-						<span class="@headerTemplate">Teaching Only <i class="fas fa-file-download ms-1"></i></span>
-					</HeaderTemplate>
-					<ChildContent>
-						<GridAnchor Href="@context.TeachingHref"
-															 Text="@context.TorahAbrv"
-															 Title="@context.TeachingPdfFile"
-															 Bold="true" />
-					</ChildContent>
-				</TemplateColumn>
+			<TemplateColumn Sortable="false">
+				<HeaderTemplate>
+					<span class="@headerTemplate">
+						Complete Service <i class="fas fa-file-download ms-1"></i>
+					</span>
+				</HeaderTemplate>
+				<ChildContent>
+					<GridAnchor Href="@context.CompleteServiceHref"
+											Text="@context.CompleteServicePdfFile"
+											Title="@context.CompleteServicePdfFile" />
+				</ChildContent>
+			</TemplateColumn>
 
-				<TemplateColumn Sortable="false">
-					<HeaderTemplate>
-						<span class="@headerTemplate">
-							Complete Service <i class="fas fa-file-download ms-1"></i>
-						</span>
-					</HeaderTemplate>
-					<ChildContent>
-						<GridAnchor Href="@context.CompleteServiceHref"
-															 Text="@context.CompleteServicePdfFile"
-															 Title="@context.CompleteServicePdfFile" />
-					</ChildContent>
-				</TemplateColumn>
-
-			</QuickGrid>
-
-			<Paginator State="pagination" />
-		</div>
+		</QuickGrid>
 	</div>
 
-	<hr class="my-1">
 
-	<!-- Items / page + filter -->
-	<div class="d-flex flex-wrap justify-content-center align-items-center gap-5">
+	<div class="d-flex justify-content-around">
+		<div class="card-footer bg-dark-subtle text-black mt-2 pt-0">
 
-		<div style="font-size: 75%;">
-			<label for="itemsPerPage" class="me-1 mb-0">Items / page</label>
-			<select id="itemsPerPage" name="itemsPerPage"
-							@onchange="OnItemsPerPageChanged"
-							class="form-select form-select-sm d-inline-block" style="width:auto;"
-							value="@selectedItemsPerPage">
-				<option value="5">5</option>
-				<option value="10">10</option>
-				<option value="20">20</option>
-				<option value="50">50</option>
-				<option value="All">All</option>
-			</select>
-		</div>
+			<Paginator State="pagination" />
 
-		<div class="input-group input-group-sm" style="max-width: 150px;">
-			<input type="text"
-						 class="form-control"
-						 placeholder="filter filenames..."
-						 @bind="fileFilter"
-						 @bind:event="oninput"
-						 @bind:after="OnFilterChanged" />
-			<button class="btn btn-outline-secondary"
-							type="button"
-							@onclick="ClearFilter"
-							disabled="@string.IsNullOrEmpty(fileFilter)">
-				Clear
-			</button>
+			<hr />
+
+			<!-- Items / page + filter -->
+			<div class="d-flex flex-wrap justify-content-center align-items-center gap-5">
+
+				<div style="font-size: 75%;" class="d-flex flex-column align-items-start">
+					<select id="itemsPerPage" name="itemsPerPage"
+									@onchange="OnItemsPerPageChanged"
+									class="form-select form-select-sm"
+									style="width: auto;"
+									value="@selectedItemsPerPage">
+						<option value="5">5</option>
+						<option value="10">10</option>
+						<option value="20">20</option>
+						<option value="50">50</option>
+						<option value="All">All</option>
+					</select>
+					<label for="itemsPerPage" class="mt-1 mb-0">Items / page</label>
+				</div>
+
+
+				@* placeholder=filter filenames... Clear *@
+				<div class="d-flex flex-column align-items-start" style="max-width: 200px;">
+					<div class="input-group input-group-sm">
+						<input type="text"
+									 class="form-control"
+									 placeholder="e.g. 2026 or Lev"
+									 @bind="fileFilter"
+									 @bind:event="oninput"
+									 @bind:after="OnFilterChanged" />
+						<button class="btn btn-outline-secondary"
+										type="button" , title="clear the filter"
+										@onclick="ClearFilter"
+										disabled="@string.IsNullOrEmpty(fileFilter)">
+							<i class="fas fa-times text-danger"></i>
+						</button>
+					</div>
+					<label class="mt-1 mb-0" style="font-size: 75%;">Filter on <b>Complete Service</b></label>
+				</div>
+			</div>
+
 		</div>
 	</div>
 

--- a/PWA/Features/Home/Shabbat/Teaching/Archives/PdfNotYetAvailableButton.razor
+++ b/PWA/Features/Home/Shabbat/Teaching/Archives/PdfNotYetAvailableButton.razor
@@ -1,10 +1,18 @@
 ﻿@using ParashaEnums = RCL.Features.Parasha.Enums
 @using RCL.Features.Parasha
 
-<button class="btn btn-outline-secondary" disabled title="No @Helpers.GetPdfTypeText(PdfType) yet">
-	<span class="fs-6">@Helpers.GetPdfTypeText(PdfType)</span>
-</button>
+<div class="d-flex flex-column align-items-center">
+	<button class="btn btn-outline-secondary" disabled title="No @Helpers.GetPdfTypeText(PdfType) yet">
+		<span class="fs-6">@Helpers.GetPdfTypeText(PdfType)</span>
+	</button>
+
+	<p class="bg-warning-subtle text-center p-small-font mt-1 mb-0 px-3" title="check back latter">
+		@FileName <br />
+		not ready yet
+	</p>
+</div>
 
 @code {
 	[Parameter, EditorRequired] public ParashaEnums.PdfType PdfType { get; set; }
+	[Parameter, EditorRequired] public string FileName { get; set; }
 }

--- a/PWA/Features/Home/Shabbat/Teaching/ButtonWrapper.razor
+++ b/PWA/Features/Home/Shabbat/Teaching/ButtonWrapper.razor
@@ -23,14 +23,14 @@
 	}
 	else
 	{
-		<PdfNotYetAvailableButton PdfType="PdfType" />
+		<PdfNotYetAvailableButton PdfType="PdfType" FileName="@fileName" />
 	}
 
 }
 else
 {
 	@* Triennial IS null *@
-	<PdfNotYetAvailableButton PdfType="PdfType" />
+	<PdfNotYetAvailableButton PdfType="PdfType" FileName="@fileName" />
 }
 
 @code {
@@ -38,6 +38,7 @@ else
 	[Parameter, EditorRequired] public ParashaEnums.PdfType PdfType { get; set; }
 	[Parameter, EditorRequired] public ParashaEnums.Triennial? Triennial { get; set; }
 
+	string fileName = "";
 	protected BlobDTO? Dto;
 	bool _loading = true;
 
@@ -49,6 +50,8 @@ else
 			_loading = false;
 			return;
 		}
+
+		fileName = Helpers.GetPdfFile(Triennial, PdfType);
 
 		Logger.LogInformation("{Method}, Start, PdfType:{PdfType}",
 			$"{nameof(ButtonWrapper)}!{nameof(OnInitializedAsync)}", PdfType);

--- a/PWA/Features/SukkotIndexCard.razor
+++ b/PWA/Features/SukkotIndexCard.razor
@@ -7,15 +7,19 @@
 			</a>
 		</div>
 	</div>
-	<div class="footer mt-0">
 
+	<div class="footer mt-0">
 		<span class="text-center @FontSize">
 			<a href="https://Sukkot.LivingMessiah.com" target="_blank">
-				<img src="/sukkot-favicon.ico" alt="Logo" width="32" height="32" class="rounded" />
+				@if (!IsXs)
+				{
+					<img src="/sukkot-favicon.ico" alt="Logo" width="32" height="32" class="rounded me-2" />
+				}
 				<u><b>Sukkot.LivingMessiah.com</b></u>
 			</a>
 			&nbsp;<i class="fas fa-arrow-right"></i>
 		</span>
+
 	</div>
 </div>
 


### PR DESCRIPTION
Improve not-ready PDF messaging with filenames, archive footer/filter layout, and hide the Sukkot favicon on XS screens.

## Summary
Polishes Home-page PDF UX and the Sukkot card:

- **Not-ready PDF:** disabled button shows the expected filename and a short "not ready yet" note (`PdfNotYetAvailableButton` + `ButtonWrapper`).
- **PDF Archive:** clearer footer layout for paginator, items/page, and filter (labels/placeholder).
- **Sukkot card:** hide favicon on XS viewports; keep the registration site link.

## Linked issue
Fixes #166

## Test plan
- [x] Local PWA (or Aspire): Home → Shabbat card — not-ready path shows filename + message; ready path still green download
- [x] Expand PDF Archive — filter and items/page usable
- [x] Sukkot card — XS (no favicon) vs larger (favicon shown)
- [x] Preview or staging (if applicable)
- [ ] Prod smoke after merge

## Risk
None — UI-only; no auth, payments, or blob API behavior changes.

## Screen Shot
<img width="588" height="837" alt="ShabbatCard-Screen-Shot" src="https://github.com/user-attachments/assets/04593610-a4b3-4650-beed-b0d21ad04fd8" />
