### PR TITLE
Add markdown-aware Sukkot schedule component (#198)

### DIFF
--- a/RCL/Features/Sukkot/Data/IScheduledEventsMarkdownRepository.cs
+++ b/RCL/Features/Sukkot/Data/IScheduledEventsMarkdownRepository.cs
@@ -1,0 +1,10 @@
+namespace RCL.Features.Sukkot.Data;
+
+/// <summary>
+/// Reads the singleton schedule markdown row from the Sukkot database.
+/// Host apps (Sukkot, eventually Admin) provide the SQL implementation.
+/// </summary>
+public interface IScheduledEventsMarkdownRepository
+{
+	Task<ScheduledEventsMarkdownQuery?> GetAsync();
+}

--- a/RCL/Features/Sukkot/Data/ScheduledEventsMarkdownQuery.cs
+++ b/RCL/Features/Sukkot/Data/ScheduledEventsMarkdownQuery.cs
@@ -1,0 +1,10 @@
+namespace RCL.Features.Sukkot.Data;
+
+/// <summary>
+/// Single-row schedule content from dbo.ScheduledEventsMarkdown.
+/// </summary>
+public sealed class ScheduledEventsMarkdownQuery
+{
+	public string Markdown { get; set; } = string.Empty;
+	public DateTime LastRevised { get; set; }
+}

--- a/RCL/Features/Sukkot/Schedule.razor
+++ b/RCL/Features/Sukkot/Schedule.razor
@@ -1,0 +1,63 @@
+@using Microsoft.Extensions.Logging
+@using RCL.Constants
+@using RCL.Features.Sukkot.Data
+@using RCL.Helpers
+
+@inject IScheduledEventsMarkdownRepository Repository
+@inject ILogger<Schedule> Logger
+
+<div class="card border border-warning border-4 bg-warning-subtle mt-4">
+	<h2 class="py-2 text-center text-black"><b>Schedule</b></h2>
+
+	@if (_isLoading)
+	{
+		<div class="card-body text-center">
+			<div class="spinner-border" role="status"></div>
+			<span class="ms-2 align-middle">Loading schedule...</span>
+		</div>
+	}
+	else if (!string.IsNullOrEmpty(_errorMessage))
+	{
+		<div class="card-body">
+			<div class="alert alert-danger mb-0" role="alert">@_errorMessage</div>
+		</div>
+	}
+	else if (_schedule is null || string.IsNullOrWhiteSpace(_schedule.Markdown))
+	{
+		<div class="card-body">
+			<p class="text-center mb-0">Schedule is not available yet.</p>
+		</div>
+	}
+	else
+	{
+		<div class="card-body markdown-body">
+			@MarkdownHelper.ToMarkup(_schedule.Markdown)
+		</div>
+		<div class="card-footer text-end small text-muted bg-warning-subtle border-0">
+			Last revised: @_schedule.LastRevised.ToString(DateFormat.ddd_MMM_dd_YYYY)
+		</div>
+	}
+</div>
+
+@code {
+	private ScheduledEventsMarkdownQuery? _schedule;
+	private bool _isLoading = true;
+	private string? _errorMessage;
+
+	protected override async Task OnInitializedAsync()
+	{
+		try
+		{
+			_schedule = await Repository.GetAsync();
+		}
+		catch (Exception ex)
+		{
+			Logger.LogError(ex, "{Method}", nameof(OnInitializedAsync));
+			_errorMessage = "Unable to load the schedule. Please try again later.";
+		}
+		finally
+		{
+			_isLoading = false;
+		}
+	}
+}

--- a/Sukkot/Features/Data/ScheduledEventsMarkdownRepository.cs
+++ b/Sukkot/Features/Data/ScheduledEventsMarkdownRepository.cs
@@ -1,0 +1,28 @@
+using Dapper;
+using Sukkot.Data;
+using RCL.Features.Sukkot.Data;
+
+namespace Sukkot.Features.Data;
+
+public class ScheduledEventsMarkdownRepository : BaseRepositoryAsync, IScheduledEventsMarkdownRepository
+{
+	public ScheduledEventsMarkdownRepository(IConfiguration config, ILogger<ScheduledEventsMarkdownRepository> logger)
+		: base(config, logger, Sukkot.Constants.ConnectionString.Sukkot)
+	{
+	}
+
+	public async Task<ScheduledEventsMarkdownQuery?> GetAsync()
+	{
+		Sql = """
+			SELECT Markdown, LastRevised
+			FROM dbo.ScheduledEventsMarkdown
+			WHERE [Lock] = 'X'
+			""";
+
+		return await WithConnectionAsync(async connection =>
+		{
+			Logger.LogDebug("{Method} Sql: {Sql}", nameof(GetAsync), Sql);
+			return await connection.QuerySingleOrDefaultAsync<ScheduledEventsMarkdownQuery>(sql: Sql);
+		});
+	}
+}

--- a/Sukkot/Features/Data/ServiceCollectionExtensions.cs
+++ b/Sukkot/Features/Data/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using RCL.Features.Sukkot.Data;
 using Sukkot.Features.Components.RegistrationForm;
 using Sukkot.Security;
 
@@ -11,6 +12,7 @@ public static class ServiceCollectionExtensions
 		services
 			.AddTransient<ISecurityHelper, SecurityHelper>()
 			.AddTransient<IRepository, Repository>()
+			.AddTransient<IScheduledEventsMarkdownRepository, ScheduledEventsMarkdownRepository>()
 			.AddTransient<IValidator<VM>, VMValidator>();
 		return services;
 	}

--- a/Sukkot/Features/LandingPage/Index.razor
+++ b/Sukkot/Features/LandingPage/Index.razor
@@ -5,6 +5,7 @@
 @using Sukkot.Security
 @using Sukkot.Security.Constants
 @using Microsoft.AspNetCore.Components.Authorization
+@using RCL.Features.Sukkot
 
 @inject ISecurityHelper? SecurityHelper
 
@@ -35,6 +36,7 @@
 
     <CalendarWeek />
     <Location />
+    <Schedule />
     <Documents />
     @* <SukkotTShirt /> *@
 


### PR DESCRIPTION
## Summary
- Add shared `RCL/Features/Sukkot/Schedule.razor` that loads and renders schedule markdown from `dbo.ScheduledEventsMarkdown`.
- Introduce `IScheduledEventsMarkdownRepository` in RCL with a Sukkot Dapper implementation and DI registration.
- Place `<Schedule />` on the Sukkot landing page below `<Location />`.

## Test plan
- [x] Confirm `ScheduledEventsMarkdown` is seeded in the Sukkot database.
- [x] Run Sukkot (or Aspire host) and open the landing page.
- [x] Verify the Schedule card appears under Location, markdown renders, and Last revised is shown.
- [x] Verify empty/missing row and DB error paths degrade gracefully.

Fixes #198