### PR TITLE
Add WeeklyDownload role for Admin weekly downloads

### DIFF
--- a/Admin/Enums/Account.cs
+++ b/Admin/Enums/Account.cs
@@ -44,7 +44,7 @@ public abstract class Account : SmartEnum<Account>
 		public LogoutSE() : base($"{nameof(Id.Logout)}", Id.Logout) { }
 		public override string Index => "/Account/Logout";
 		public override string Title => "Log out";
-		public override string Icon => "fas fa-sign-in-alt";
+		public override string Icon => "fas fa-sign-out-alt";
 		public override string Action => "Account/LogOut";
 	}
 

--- a/Admin/Enums/Nav.cs
+++ b/Admin/Enums/Nav.cs
@@ -193,7 +193,7 @@ public abstract class Nav : SmartEnum<Nav>
 		public override string Icon => "fas fa-file-pdf";
 		public override int Sort => Id.WeeklyDownload;
 		public override bool Disabled => false;
-		public override int RequiredRoles => RoleEnum.KeyDates.Value | RoleEnum.Admin.Value; // KeyDates or Admin role
+		public override int RequiredRoles => RoleEnum.WeeklyDownload.Value | RoleEnum.Admin.Value; 
 	}
 
 	private sealed class SukkotScheduleSE : Nav

--- a/Admin/Features/Home/NavList.razor
+++ b/Admin/Features/Home/NavList.razor
@@ -102,6 +102,8 @@
 				userRoles |= RoleEnum.KeyDates.Value;
 			else if (roleClaim.Value == RoleEnum.Sukkot.Claim)
 				userRoles |= RoleEnum.Sukkot.Value;
+			else if (roleClaim.Value == RoleEnum.WeeklyDownload.Claim)
+				userRoles |= RoleEnum.WeeklyDownload.Value;
 			else if (roleClaim.Value == RoleEnum.SukkotHost.Claim)
 				userRoles |= RoleEnum.SukkotHost.Value;
 			else if (roleClaim.Value == RoleEnum.Announcements.Claim)

--- a/Admin/Features/WeeklyDownloads/Index.razor
+++ b/Admin/Features/WeeklyDownloads/Index.razor
@@ -11,15 +11,15 @@
 
 @* ToDo: add different RoleGroup.UploadToBlo or something *@
 
-<AuthorizeView Policy=@RoleGroup.KeyDates>
+<AuthorizeView Policy=@RoleGroup.WeeklyDownload>
   <Authorized>
 <UploadCard />
 	</Authorized>
 	<NotAuthorized>
 		<div class="alert alert-warning text-end" role="alert">
-			<small>Not Authorized; Role Group Policy: @RoleGroup.KeyDates</small>
+			<small>Not Authorized; Role Group Policy: @RoleGroup.WeeklyDownload</small>
 		</div>
-		<LoginRedirectCard Nav="Nav.KeyDates" ReturnUrl=@Nav.KeyDates.Index />
+		<LoginRedirectCard Nav="Nav.WeeklyDownload" ReturnUrl=@Nav.WeeklyDownload.Index />
 	</NotAuthorized>
 </AuthorizeView>
 

--- a/Admin/Security/Enums/Role.cs
+++ b/Admin/Security/Enums/Role.cs
@@ -10,7 +10,8 @@ public enum RoleFlag
 	Announcements = 2,
 	KeyDates = 4,
 	Sukkot = 8,
-	SukkotHost = 16
+	SukkotHost = 16,
+	Weeklydownload = 32
 }
 
 public abstract class Role : SmartEnum<Role>
@@ -24,6 +25,7 @@ public abstract class Role : SmartEnum<Role>
 		internal const int KeyDates = 4;  
 		internal const int Sukkot = 8;
 		internal const int SukkotHost = 16;
+		internal const int WeeklyDownload = 32;
 	}
 	#endregion
 
@@ -33,6 +35,7 @@ public abstract class Role : SmartEnum<Role>
 	public static readonly Role KeyDates = new KeyDatesSE();
 	public static readonly Role Sukkot = new SukkotSE();
 	public static readonly Role SukkotHost = new SukkotHostSE();
+	public static readonly Role WeeklyDownload = new WeeklyDownloadSE();
 	#endregion
 
 	private Role(string name, int value) : base(name, value)  // Constructor
@@ -73,6 +76,12 @@ public abstract class Role : SmartEnum<Role>
 	{
 		public SukkotHostSE() : base($"{nameof(BitwiseId.SukkotHost)}", BitwiseId.SukkotHost) { }
 		public override string Claim => "sukkothost";
+	}
+
+	private sealed class WeeklyDownloadSE : Role
+	{
+		public WeeklyDownloadSE() : base($"{nameof(BitwiseId.WeeklyDownload)}", BitwiseId.WeeklyDownload) { }
+		public override string Claim => "weeklydownload";
 	}
 
 	#endregion

--- a/Admin/Security/Enums/RoleGroup.cs
+++ b/Admin/Security/Enums/RoleGroup.cs
@@ -9,4 +9,5 @@ public static class RoleGroup
 	public const string KeyDates = "keydates";
 	public const string Sukkot = "sukkot";
 	public const string SukkotHost = "sukkothost";
+	public const string WeeklyDownload = "weeklydownload";
 }

--- a/Admin/Security/ServiceCollectionExtensions.cs
+++ b/Admin/Security/ServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ public static class ServiceCollectionExtensions
 								context.User.HasClaim(Authentication.Claim, "true") &&
 								(context.User.IsInRole(RoleEnum.Announcements.Claim) ||
 								 context.User.IsInRole(RoleEnum.KeyDates.Claim) ||
+								 context.User.IsInRole(RoleEnum.WeeklyDownload.Claim) ||
 								 context.User.IsInRole(RoleEnum.Sukkot.Claim) ||
 								 context.User.IsInRole(RoleEnum.SukkotHost.Claim) ||
 								 context.User.IsInRole(RoleEnum.Admin.Claim))))
@@ -44,6 +45,11 @@ public static class ServiceCollectionExtensions
 				.AddPolicy(RoleGroup.SukkotHost, policy =>
 						policy.RequireAssertion(context =>
 								context.User.IsInRole(RoleEnum.SukkotHost.Claim) ||
+								context.User.IsInRole(RoleEnum.Admin.Claim)))
+
+				.AddPolicy(RoleGroup.WeeklyDownload, policy =>
+						policy.RequireAssertion(context =>
+								context.User.IsInRole(RoleEnum.WeeklyDownload.Claim) ||
 								context.User.IsInRole(RoleEnum.Admin.Claim)))
 
 				.AddPolicy(RoleEnum.Admin.Name, policy => policy.RequireRole(RoleEnum.Admin.Claim, "true"));

--- a/Sukkot/Enums/Nav.cs
+++ b/Sukkot/Enums/Nav.cs
@@ -148,7 +148,7 @@ public abstract class Nav : SmartEnum<Nav>
 		public LogoutSE() : base($"{nameof(Id.Logout)}", Id.Logout) { }
 		public override string Index => "/Account/Logout";
 		public override string Title => "Log out";
-		public override string Icon => "fas fa-sign-in-alt";
+		public override string Icon => "fas fa-sign-out-alt";
 		public override bool IsOnToolbar => false;
 	}
 


### PR DESCRIPTION
## Summary
- Add a dedicated `WeeklyDownload` role/claim and authorization policy so non-admin users can be granted Weekly Downloads access
- Wire nav, home role mapping, and the Weekly Downloads page to the new policy
- Small logout icon fix (`sign-in` → `sign-out`) in Admin and Sukkot

## Test plan
- [x] Admin user can still open Weekly Downloads
- [x] User with only `weeklydownload` claim can open Weekly Downloads and see the upload UI
- [x] User without Admin or WeeklyDownload cannot access the page (Not Authorized)
- [x] Home nav list shows Weekly Download only when the claim/role is present
- [x] Auth0: confirm `weeklydownload` role/claim is configured for intended users

Fixes #208