### PR TITLE
Fix Stripe checkout session 404 and polish payment print UI

### DIFF
--- a/Sukkot/Features/Payment/PaymentConfirm.razor
+++ b/Sukkot/Features/Payment/PaymentConfirm.razor
@@ -15,9 +15,6 @@
 
 <AuthorizeView Policy=@Policy.Name>
   <Authorized>
-    <div class="pb-2 mt-4 mb-2 border-bottom">
-      <h1><span class="text-secondary @Nav.ConfirmRegistration.Icon"></span> @Nav.ConfirmRegistration.Title</h1>
-    </div>
 
     <div class="d-flex justify-content-center mt-4">
 
@@ -112,7 +109,7 @@
   {
     if (id is not null)
     {
-      NavigationManager!.NavigateTo($"{Nav.Print.Index}/{id}/true");
+      NavigationManager!.NavigateTo($"{Nav.Print.Index}/{id}/");
     }
   }
 }

--- a/Sukkot/Features/Print/Details.razor
+++ b/Sukkot/Features/Print/Details.razor
@@ -3,47 +3,57 @@
 @using StepEnums = RCL.Features.Sukkot.Enums.Step
 @using RegistrationFeeEnums = RCL.Features.Sukkot.Enums.RegistrationFee
 
-<h4 class="my-4 text-center border-bottom border-dark-subtle border-4">@Constants.Details.Title</h4>
+<div class="d-flex justify-content-between align-items-center">
+	<span>Receipt</span>
+
+	<span class="text-center">@Constants.Details.Title</span>
+
+	<a class="btn btn-outline-secondary btn-sm" href="javascript:window.print()">
+		<span class="fas fa-print me-1"></span> Print
+	</a>
+</div>
+
+<hr class="border-dark-subtle border-4 my-2">
 
 <div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
 
-  <div class="d-flex justify-content-around">
-    <div><b>Name</b>: @RegistrationQuery!.FullName(false); <i>@RegistrationQuery!.OtherNames</i></div>
+	<div class="d-flex justify-content-around">
+		<div><b>Name</b>: @RegistrationQuery!.FullName(false); <i>@RegistrationQuery!.OtherNames</i></div>
 
-    <div><b>Registration#</b>: @RegistrationQuery!.Id</div>
-  </div>
+		<div><b>Registration#</b>: @RegistrationQuery!.Id</div>
+	</div>
 
-  <div class="d-flex justify-content-around">
-    <div><b>EMail / Phone</b>: @RegistrationQuery!.EMail @Phone2</div>
+	<div class="d-flex justify-content-around">
+		<div><b>EMail / Phone</b>: @RegistrationQuery!.EMail @Phone2</div>
 
-    <div class=" @StepEnums.FromValue(RegistrationQuery.StepId).CardBodyCSS"><b>Step</b>: @RegistrationQuery.StepName</div>
+		<div class=" @StepEnums.FromValue(RegistrationQuery.StepId).CardBodyCSS"><b>Step</b>: @RegistrationQuery.StepName</div>
 
-  </div>
+	</div>
 
 </div>
 
 @* House Rules Agreement *@
 <div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
-  <div class="d-flex justify-content-center">
-    <b>House Rules Agreement</b>:
-    Agreed on @RegistrationQuery!.HouseRulesAgreementDate
-  </div>
+	<div class="d-flex justify-content-center">
+		<b>House Rules Agreement</b>:
+		Agreed on @RegistrationQuery!.HouseRulesAgreementDate
+	</div>
 </div>
 
 
 @* Attendance *@
 
 <div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
-  <div class="d-flex justify-content-center">
-    <b>Attendance</b>:&nbsp;
-    <ul class="list-inline">
-      <li class="list-inline-item">Adults: <span class="">@RegistrationQuery!.Adults</span></li>
-      <li class="list-inline-item">Child (Big):<span class="">@RegistrationQuery!.ChildBig</span></li>
-      <li class="list-inline-item">Child (Small):<span class="">@RegistrationQuery!.ChildSmall</span></li>
-    </ul>
-  </div>
+	<div class="d-flex justify-content-center">
+		<b>Attendance</b>:&nbsp;
+		<ul class="list-inline">
+			<li class="list-inline-item">Adults: <span class="">@RegistrationQuery!.Adults</span></li>
+			<li class="list-inline-item">Child (Big):<span class="">@RegistrationQuery!.ChildBig</span></li>
+			<li class="list-inline-item">Child (Small):<span class="">@RegistrationQuery!.ChildSmall</span></li>
+		</ul>
+	</div>
 
-@*   
+	@*
   <div class="d-flex justify-content-center mb-4">
     <AttendanceEditDateList @bind-SelectedDates="VM.AttendanceDateList" />
     AttendanceDateList
@@ -51,12 +61,12 @@
  *@
 
 
-@*       
+	@*
   <div class="@MediaQuery.Xs.DivClass">
     <div class="d-flex justify-content-center mb-4">
       <AttendanceDateCalendar IsXs="true"
                               AttendanceDateList="RegistrationQuery!.AttendanceDateList"
-                              AttendanceDateList2ndMonth="RegistrationQuery!.AttendanceDateList2ndMonth" /> 
+                              AttendanceDateList2ndMonth="RegistrationQuery!.AttendanceDateList2ndMonth" />
     </div>
   </div>
 
@@ -72,74 +82,74 @@
 </div>
 
 <div class="d-flex justify-content-center">
-  <div class="mx-3">
-    AttendanceBitwise: @RegistrationQuery.AttendanceBitwise; Count: @(RegistrationQuery.AttendanceDateList?.Count() ?? 0)
-    <AttendanceDateList SelectedDates="@RegistrationQuery.AttendanceDateList" />
-  </div>
+	<div class="mx-3">
+		@* AttendanceBitwise: @RegistrationQuery.AttendanceBitwise; Count: @(RegistrationQuery.AttendanceDateList?.Count() ?? 0) *@
+		<AttendanceDateList SelectedDates="@RegistrationQuery.AttendanceDateList" />
+	</div>
 </div>
 
 @* Cost *@
 <div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
-  <div class="d-flex justify-content-center mb-2">
-    <span class="p-1"><b>Registration Donation</b>:&nbsp;</span>
-    <span class="p-1 bg-warning-subtle text-black">
-      @Fee
-    </span>
-  </div>
+	<div class="d-flex justify-content-center mb-2">
+		<span class="p-1"><b>Registration Donation</b>:&nbsp;</span>
+		<span class="p-1 bg-warning-subtle text-black">
+			@Fee
+		</span>
+	</div>
 </div>
 
 @* Donation *@
 @if (RegistrationQuery.DonationQuery is not null)
 {
-  <div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
-    <div class="d-flex justify-content-center mb-2">
-      <span class="p-1"><b>Paid Amount</b>:&nbsp;</span>
-      <span class="p-1 bg-warning-subtle text-black">@(RegistrationQuery.DonationQuery!.Amount.ToString("C2"))</span>
-    </div>
-    <div class="d-flex justify-content-center mb-2">
-      <span class="p-1"><b>Reference</b>:&nbsp;</span>
-      <span class="p-1 text-black"><small>@(RegistrationQuery.DonationQuery!.ReferenceId)</small></span>
-    </div>
-    <div class="d-flex justify-content-center mb-2">
-      <span class="p-1"><b>Date</b>:&nbsp;</span>
-      <span class="p-1 text-black">@(RegistrationQuery.DonationQuery!.CreateDate)</span>
-    </div>
-  </div>
+	<div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
+		<div class="d-flex justify-content-center mb-2">
+			<span class="p-1"><b>Paid Amount</b>:&nbsp;</span>
+			<span class="p-1 bg-warning-subtle text-black">@(RegistrationQuery.DonationQuery!.Amount.ToString("C2"))</span>
+		</div>
+		<div class="d-flex justify-content-center mb-2">
+			<span class="p-1"><b>Reference</b>:&nbsp;</span>
+			<span class="p-1 text-black"><small>@(RegistrationQuery.DonationQuery!.ReferenceId)</small></span>
+		</div>
+		<div class="d-flex justify-content-center mb-2">
+			<span class="p-1"><b>Date</b>:&nbsp;</span>
+			<span class="p-1 text-black">@(RegistrationQuery.DonationQuery!.CreateDate)</span>
+		</div>
+	</div>
 }
 
 @* Notes *@
 @if (!String.IsNullOrEmpty(RegistrationQuery!.Notes))
 {
-  <div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
-    <div class="d-flex justify-content-center">
-      <b>Notes</b>: @RegistrationQuery!.Notes
-    </div>
-  </div>
+	<div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
+		<div class="d-flex justify-content-center">
+			<b>Notes</b>: @RegistrationQuery!.Notes
+		</div>
+	</div>
 }
 
 @* Address (print only) *@
 <div class="d-none d-print-block">
-  <div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
-    <div class="d-flex justify-content-center">
-      <Address OnOneLine="true" UseLabel="true" />
-    </div>
-  </div>
+	<div class="mt-2 mb-4 border-bottom border-dark-subtle border-2">
+		<div class="d-flex justify-content-center">
+			<Address OnOneLine="true" UseLabel="true" />
+		</div>
+	</div>
 </div>
 
 @code {
-  [Parameter, EditorRequired] public RegistrationQuery? RegistrationQuery { get; set; }
+	[Parameter, EditorRequired] public RegistrationQuery? RegistrationQuery { get; set; }
 
-  string Phone2 = string.Empty;
-  string Fee = "___";
+	string Phone2 = string.Empty;
+	string Fee = "___";
 
-  protected override void OnParametersSet()
-  {
-    Phone2 = !String.IsNullOrEmpty(RegistrationQuery!.Phone) ? $" / Phone: {RegistrationQuery!.Phone} " : "";
+	protected override void OnParametersSet()
+	{
+		Phone2 = !String.IsNullOrEmpty(RegistrationQuery!.Phone) ? $" / Phone: {RegistrationQuery!.Phone} " : "";
 
-    if (RegistrationFeeEnums.TryFromValue(RegistrationQuery.FeeEnumValue, out var registrationFee))
-    {
-      Fee = registrationFee!.CurrencyFormat; 
-    }
+		if (RegistrationFeeEnums.TryFromValue(RegistrationQuery.FeeEnumValue, out var registrationFee))
+		{
+			Fee = registrationFee!.CurrencyFormat;
+		}
 
-  }
+	}
 }

--- a/Sukkot/Features/Print/Index.razor
+++ b/Sukkot/Features/Print/Index.razor
@@ -17,17 +17,11 @@
 @inject ISecurityHelper? SecurityHelper
 @inject Data.IRepository? db
 
-<PageHeader PageEnum="Nav.Print" />
-
 <PhaseWrapper>
   <OpenContent>
 
     <AuthorizeView Policy=@Policy.Name>
       <Authorized>
-
-        <p class="fs-4 text-danger">ToDo: Remove Toolbar inside Print.Index</p>
-        @* <Toolbar /> *@
-        
         <LoadingComponent IsLoading="RegistrationQuery == null" TurnSpinnerOff=TurnSpinnerOff>
 
           @if (IsAuthorized)

--- a/Sukkot/Features/Steps/PaymentStep/StripeCard.razor
+++ b/Sukkot/Features/Steps/PaymentStep/StripeCard.razor
@@ -23,7 +23,7 @@
   [Parameter, EditorRequired] public int RegistrationId { get; set; }
   [Parameter, EditorRequired] public string Email { get; set; }
 
-  string? Action => $"{DonationConstants.BaseSessionUrl}-sukkotregistration";
+  string? Action => DonationConstants.BaseSessionUrl;
 
   // protected override void OnInitialized()
   // {

--- a/Sukkot/Layout/Footer.razor
+++ b/Sukkot/Layout/Footer.razor
@@ -14,7 +14,7 @@
     <img src="/icons/lmfavicon.ico" alt="Logo" width="32" height="32" class="rounded" />
     LivingMessiah.com
   </a>
-  <p>Running on Linux</p>
+  @* <p>Running on Linux</p> *@
 </div>
 
 @code {


### PR DESCRIPTION
## Summary
- Align Sukkot donation form `action` with the mapped `/api/stripe/create-session` endpoint so Step 3 no longer posts to a non-existent `-sukkotregistration` path (404).
- Simplify payment confirm → print navigation and tidy receipt/print UI.
- Minor footer cleanup.

## Test plan
- [x] Local: open registration Step 3 Donation, submit Stripe Processing — no 404; reaches create-session (requires valid `Stripe:ApiKey` user-secret).
- [x] Local/test mode: complete Stripe Checkout and land on PaymentConfirm.
- [x] From PaymentConfirm, open print/receipt and verify layout/print button.
- [ ] After deploy: smoke the same path on sukkot host with configured Stripe secrets.

Fixes #210