### PR TITLE
Fix Admin and Sukkot production logging for Linux App Service

### DIFF
--- a/Admin/Admin.csproj
+++ b/Admin/Admin.csproj
@@ -33,9 +33,14 @@
 		<PackageReference Include="Blazored.Typeahead" Version="4.7.0" />
 		<PackageReference Include="CsvHelper" Version="33.1.0" />
 		<PackageReference Include="Dapper" Version="2.1.79" />
+		<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.9" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
+		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.16.0" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
 		<PackageReference Include="Seq.Extensions.Logging" Version="9.0.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
 		<PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
@@ -44,6 +49,7 @@
 		<PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+		<PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
 		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="5.0.0" />
 		<PackageReference Include="Serilog.Sinks.Seq" Version="9.1.0" />
 		<PackageReference Include="Stripe.net" Version="52.1.0" />

--- a/Admin/Program.cs
+++ b/Admin/Program.cs
@@ -21,6 +21,10 @@ using Admin.SecurityRoot;  // Added for ServiceCollectionExtensions
 using Admin.Settings;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Azure.Monitor.OpenTelemetry.Exporter;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 using Serilog;
 
 using AccountEnum = Admin.Enums.Account;
@@ -34,12 +38,53 @@ using WeeklyDownloadsSettings = Admin.Features.WeeklyDownloads.Settings;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
+
+var aiConnectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")
+	?? builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
+
 Log.Logger = new LoggerConfiguration().ReadFrom.Configuration(builder.Configuration).CreateLogger();
-Log.Warning("{Class}, Environment: {Environment}; ", nameof(Program), Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"));
+Log.Warning("{Class}, Environment: {Environment}; ApplicationInsightsConfigured: {ApplicationInsightsConfigured}",
+	nameof(Program),
+	Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"),
+	!string.IsNullOrWhiteSpace(aiConnectionString));
 
 try
 {
 	builder.Host.UseSerilog((ctx, lc) => lc.ReadFrom.Configuration(builder.Configuration));
+
+	builder.Logging.AddOpenTelemetry(options =>
+	{
+		options.IncludeScopes = true;
+		options.IncludeFormattedMessage = true;
+		options.ParseStateValues = true;
+		options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("Admin"));
+		if (!string.IsNullOrWhiteSpace(aiConnectionString))
+		{
+			options.AddAzureMonitorLogExporter(o => o.ConnectionString = aiConnectionString);
+		}
+		else
+		{
+			options.AddConsoleExporter();
+		}
+	});
+
+	builder.Services.AddOpenTelemetry()
+		.WithTracing(tracerProviderBuilder =>
+		{
+			tracerProviderBuilder
+				.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("Admin"))
+				.AddAspNetCoreInstrumentation()
+				.AddHttpClientInstrumentation();
+
+			if (!string.IsNullOrWhiteSpace(aiConnectionString))
+			{
+				tracerProviderBuilder.AddAzureMonitorTraceExporter(o => o.ConnectionString = aiConnectionString);
+			}
+			else
+			{
+				tracerProviderBuilder.AddConsoleExporter();
+			}
+		});
 
 	builder.Services.AddBlazoredToast();
 
@@ -62,7 +107,6 @@ try
 	builder.Services.AddAuth0Authentication(builder.Configuration);  // Added: configures Auth0 authentication
 
 	//builder.Services.AddFeastDayPlanner();
-	//builder.Services.AddApplicationInsightsTelemetry();
 
 	builder.Services.Configure<HealthChecksSukkot.Settings.Stripe>(builder.Configuration.GetSection(nameof(HealthChecksSukkot.Settings.Stripe)));
 	builder.Services.AddHealthChecks().AddCheck<HealthChecksSukkot.StripeWebhookHealthCheck>(HealthChecksSukkotEndPoint.HealthCheckName);

--- a/Admin/appsettings.Production.json
+++ b/Admin/appsettings.Production.json
@@ -1,6 +1,6 @@
 {
   "Serilog": {
-    "Using": [ "Serilog.Sinks.File", "Serilog.Sinks.Console" ],
+    "Using": [ "Serilog.Sinks.File", "Serilog.Sinks.Console", "Serilog.Sinks.OpenTelemetry" ],
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
@@ -11,9 +11,15 @@
     "Enrich": [ "FromLogContext", "WithMachineName", "WithProcessId", "WithThreadId" ],
     "WriteTo": [
       {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {SourceContext} {Message:lj}{NewLine}{Exception}"
+        }
+      },
+      {
         "Name": "File",
         "Args": {
-          "path": "D:\\home\\LogFiles\\Application\\log-.txt",
+          "path": "/home/LogFiles/Application/log-.txt",
           "rollingInterval": "Day",
           "rollOnFileSizeLimit": true,
           "fileSizeLimitBytes": 5242880,
@@ -22,10 +28,9 @@
         }
       },
       {
-        "Name": "ApplicationInsights",
+        "Name": "OpenTelemetry",
         "Args": {
-          "restrictedToMinimumLevel": "Information",
-          "telemetryConverter": "Serilog.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
+          "restrictedToMinimumLevel": "Information"
         }
       }
     ]

--- a/Sukkot/Program.cs
+++ b/Sukkot/Program.cs
@@ -51,16 +51,16 @@ Log.Logger = new LoggerConfiguration()
 	.ReadFrom.Configuration(configuration)
 	.CreateLogger();
 
-Log.Warning("{Class}, {Environment}, AppSettingJsonFile: {AppSettingJsonFile}; "
-			, nameof(Program), Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"), appSettingJson);
+Log.Warning("{Class}, {Environment}, AppSettingJsonFile: {AppSettingJsonFile}; ApplicationInsightsConfigured: {ApplicationInsightsConfigured}",
+	nameof(Program),
+	Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"),
+	appSettingJson,
+	!string.IsNullOrWhiteSpace(aiConnectionString));
 
 try
 {
 	builder.Host.UseSerilog((ctx, lc) => lc.ReadFrom.Configuration(configuration));
 
-	#region added by AI
-	// Clear built-in providers and add OpenTelemetry logging which will export to Azure Monitor if configured
-	builder.Logging.ClearProviders();
 	builder.Logging.AddOpenTelemetry(options =>
 	{
 		options.IncludeScopes = true;
@@ -94,9 +94,6 @@ try
 					tracerProviderBuilder.AddConsoleExporter(); // from OpenTelemetry.Exporter.Console
 				}
 			});
-
-	#endregion
-
 
 	// Services.Add
 	builder.Services.AddBlazoredToast();

--- a/Sukkot/appsettings.Production.json
+++ b/Sukkot/appsettings.Production.json
@@ -11,9 +11,15 @@
     "Enrich": [ "FromLogContext", "WithMachineName", "WithProcessId", "WithThreadId" ],
     "WriteTo": [
       {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {SourceContext} {Message:lj}{NewLine}{Exception}"
+        }
+      },
+      {
         "Name": "File",
         "Args": {
-          "path": "D:\\home\\LogFiles\\Application\\log-.txt",
+          "path": "/home/LogFiles/Application/log-.txt",
           "rollingInterval": "Day",
           "rollOnFileSizeLimit": true,
           "fileSizeLimitBytes": 5242880,


### PR DESCRIPTION
Fixes #220

## Why
Admin and Sukkot run on Linux App Services, but production Serilog still used the Windows path `D:\home\LogFiles\Application\log-.txt`. Neither app wrote to Console, so Log Stream was empty. Application Insights showed HTTP requests only — no traces or exceptions.

## What changed
- Admin: Azure Monitor OpenTelemetry log/trace export (service name `Admin`), Console sink, Linux file path `/home/LogFiles/Application/log-.txt`
- Sukkot: same Console + Linux file sinks; stop calling `ClearProviders()` after `UseSerilog` so `ILogger` still reaches Serilog
- Replaced Admin's unused Serilog Application Insights sink (package was never referenced)

## Out of scope
Unrelated local Dashboard edits (`DonationTable.razor`, `StripeTable.razor`) were left uncommitted.

## Verify
- [x] `dotnet build Admin/Admin.csproj -c Release`
- [x] `dotnet build Sukkot/Sukkot.csproj -c Release`
- After merge / deploy:
  - App Service Log Stream on `livingmessiah-admin` and `livingmessiah-sukkot`
  - SSH: `/home/LogFiles/Application/log-YYYYMMDD.txt`
  - Application Insights Logs:

```kusto
exceptions
| where timestamp > ago(7d)
| order by timestamp desc
```