### PR TITLE
Fix Sukkot Stripe webhook not writing donations

### DIFF
--- a/Admin/HealthChecks/Sukkot/Endpoints/Constants/StripeConstants.cs
+++ b/Admin/HealthChecks/Sukkot/Endpoints/Constants/StripeConstants.cs
@@ -4,7 +4,11 @@ public static class StripeConstants
 {
 	public const string ApiKey = "Stripe:ApiKey"; 
 	public const string WebhookSecret = "Stripe:WebhookSecret";
-	public const string WebhookUrl = "https://livingmessiah.com/webhook/stripesukkotdonation";
+	/// <summary>
+	/// Production Sukkot App Service origin (not the PWA at livingmessiah.com).
+	/// Stripe Dashboard endpoint must match this host + path.
+	/// </summary>
+	public const string WebhookUrl = "https://sukkot.livingmessiah.com/webhook/stripesukkotdonation";
 	public const string HealthCheckUrl = "/health/sukkot/stripe";
 	public const string HealthCheckName = "Is Stripe Webhook Enabled"; 
 }

--- a/Sukkot/AGENTS.md
+++ b/Sukkot/AGENTS.md
@@ -5,7 +5,7 @@ Blazor **Server** app for Sukkot registration and related flows (`net10.0`). Inc
 ## Layout
 
 - Features: `Features/` (registration, donations, lifecycle authority, etc.)
-- Minimal APIs / Stripe: `Endpoints/` (checkout session, webhook) — flow & DB write path: [`docs/Sukkot-Stripe-Endpoints.md`](../docs/Sukkot-Stripe-Endpoints.md)
+- Minimal APIs / Stripe: `Endpoints/` (checkout session, webhook) — flow & DB write path: [`docs/Sukkot-Stripe-Endpoints.md`](../docs/Sukkot-Stripe-Endpoints.md); local webhook test runbook: [`docs/Sukkot-Stripe-Webhook-Local-Test.md`](../docs/Sukkot-Stripe-Webhook-Local-Test.md)
 - Auth / policies: `Security/`
 - Data helpers: `Data/`, feature `Data/` folders
 - Shared enums/helpers for Sukkot dates/fees: prefer `RCL/Features/Sukkot/` when shared; app-specific UI stays here

--- a/Sukkot/Endpoints/Constants/StripeConstants.cs
+++ b/Sukkot/Endpoints/Constants/StripeConstants.cs
@@ -2,8 +2,12 @@
 
 public static class StripeConstants
 {
-	public const string ApiKey = "Stripe:ApiKey"; 
+	public const string ApiKey = "Stripe:ApiKey";
 	public const string WebhookSecret = "Stripe:WebhookSecret";
 	public const string RequestHeaders = "Stripe-Signature";
 	public const string EventType = "checkout.session.completed";
+
+	/// <summary>Committed sample values in appsettings.json — not real secrets.</summary>
+	public const string PlaceholderApiKey = "sk_test_your_stripe_api_key";
+	public const string PlaceholderWebhookSecret = "whsec_...";
 }

--- a/Sukkot/Endpoints/Data/Repository.cs
+++ b/Sukkot/Endpoints/Data/Repository.cs
@@ -71,7 +71,7 @@ public class Repository : BaseRepositoryAsync, IRepository
 		int NewId = 0;
 		string ErrorMsg = "";
 
-		Logger.LogDebug("{Method}, {RegistrationId}, Calling: {Sql}", nameof(DonationInsert), donation.RegistrationId, nameof(GetDonationRowCountByRegistrationId));
+		Logger.LogDebug("{Method}, {RegistrationId}, Calling: {Calling}", nameof(DonationInsert), donation.RegistrationId, nameof(GetDonationRowCountByRegistrationId));
 		int rowCount = await GetDonationRowCountByRegistrationId(donation.RegistrationId);
 
 		if (rowCount > 0)
@@ -95,7 +95,7 @@ public class Repository : BaseRepositoryAsync, IRepository
 
 		Parms.Add("@NewId", dbType: DbType.Int32, direction: ParameterDirection.Output);
 
-		//Logger.LogDebug("{Method}, {RegistrationId}, {Sql}", nameof(DonationInsert), donation.RegistrationId, Sql);
+		Logger.LogDebug("{Method}, {RegistrationId}, {Sql}", nameof(DonationInsert), donation.RegistrationId, Sql);
 
 		return await WithConnectionAsync(async connection =>
 		{
@@ -109,7 +109,7 @@ public class Repository : BaseRepositoryAsync, IRepository
 			else
 			{
 				NewId = int.TryParse(x.ToString(), out NewId) ? NewId : 0;
-				Logger.LogDebug("{Method}, {Message}", nameof(DonationInsert), $"Returning NewId: {NewId}");
+				Logger.LogInformation("{Method}, {Message}", nameof(DonationInsert), $"Returning NewId: {NewId}");
 			}
 
 			return new Tuple<int, string>(NewId, ErrorMsg);

--- a/Sukkot/Endpoints/Webhook.cs
+++ b/Sukkot/Endpoints/Webhook.cs
@@ -1,4 +1,4 @@
-﻿using Stripe;
+using Stripe;
 using Stripe.Checkout;
 using RegistrationFeeEnums = RCL.Features.Sukkot.Enums.RegistrationFee;
 using static Sukkot.Features.Constants.FormFields;
@@ -9,6 +9,9 @@ namespace Sukkot.Endpoints;
 
 public static class Webhook
 {
+	/// <summary>Fits dbo.Donation.CreatedBy nvarchar(25).</summary>
+	private const string DonationCreatedBy = "Stripe Webhook";
+
 	public static void WebhookConfig(this IEndpointRouteBuilder endpoints, string webhookUrl)
 	{
 		endpoints.MapPost(webhookUrl, async (
@@ -20,87 +23,133 @@ public static class Webhook
 			var Logger = loggerFactory.CreateLogger(nameof(Webhook));
 			var json = await new StreamReader(context.Request.Body).ReadToEndAsync();
 
-			//LogSecret(webhookUrl, config, Logger); // ToDo: comment out in production
+			if (string.IsNullOrWhiteSpace(json))
+			{
+				Logger.LogWarning("{Method}, Empty request body", nameof(WebhookConfig));
+				return Results.BadRequest("Empty body");
+			}
 
 			try
 			{
-				var stripeEvent = EventUtility.ConstructEvent(
-									json,
-									context.Request.Headers[StripeConstants.RequestHeaders],
-									config[StripeConstants.WebhookSecret],
-									throwOnApiVersionMismatch: false);
-
-				// Logger.LogInformation("...ET: {ET}", stripeEvent.Type);
-
-				if (stripeEvent.Type == StripeConstants.EventType)
+				var webhookSecret = config[StripeConstants.WebhookSecret];
+				if (string.IsNullOrWhiteSpace(webhookSecret))
 				{
-					Logger.LogDebug("{Method}, {Message}, {EventType}", nameof(WebhookConfig), $"webhookUrl: {webhookUrl}", stripeEvent.Type);
-					var session = stripeEvent.Data.Object as Session;
-
-					Logger.LogInformation("{Method}, {Message}", nameof(WebhookConfig), $"Email: {session!.CustomerEmail}"); 		
-
-					var (amountError, amount) = ValidateAmount(session);
-					if (!string.IsNullOrEmpty(amountError))
-					{
-						Logger.LogError("{Method}, Validation failed: {ErrorMessage}", nameof(WebhookConfig), amountError);
-						return Results.BadRequest($"{amountError}".Trim());
-					}
-
-					var (registrationIdError, registrationId) = ValidateRegistrationId(session);
-					if (!string.IsNullOrEmpty(registrationIdError))
-					{
-						Logger.LogError("{Method}, Validation failed: {ErrorMessage}", nameof(WebhookConfig), registrationIdError);
-						return Results.BadRequest($"{registrationIdError}".Trim());
-					}
-
-					var (insertError, newId) = await InsertDonation(db, Logger, session, amount, registrationId);
-					if (!string.IsNullOrEmpty(insertError))
-					{
-						Logger.LogError("{Method}, DB Insertion failed: {ErrorMessage}", nameof(WebhookConfig), insertError);
-						return Results.BadRequest($"{insertError}".Trim());
-					}
+					Logger.LogError("{Method}, Stripe:WebhookSecret is not configured", nameof(WebhookConfig));
+					return Results.BadRequest("Webhook secret not configured");
 				}
 
+				var signature = context.Request.Headers[StripeConstants.RequestHeaders].ToString();
+				if (string.IsNullOrWhiteSpace(signature))
+				{
+					Logger.LogWarning("{Method}, Missing Stripe-Signature header", nameof(WebhookConfig));
+					return Results.BadRequest("Missing Stripe-Signature");
+				}
+
+				var stripeEvent = EventUtility.ConstructEvent(
+									json,
+									signature,
+									webhookSecret,
+									throwOnApiVersionMismatch: false);
+
+				Logger.LogInformation("{Method}, Stripe event accepted: {EventId} type={EventType}",
+					nameof(WebhookConfig), stripeEvent.Id, stripeEvent.Type);
+
+				if (stripeEvent.Type != StripeConstants.EventType)
+				{
+					// Acknowledge other event types so Stripe does not retry forever.
+					Logger.LogDebug("{Method}, Ignoring event type {EventType}", nameof(WebhookConfig), stripeEvent.Type);
+					return Results.Ok();
+				}
+
+				if (stripeEvent.Data.Object is not Session session)
+				{
+					Logger.LogError("{Method}, Event data is not a Checkout Session", nameof(WebhookConfig));
+					return Results.BadRequest("Expected checkout Session payload");
+				}
+
+				Logger.LogInformation("{Method}, checkout.session.completed SessionId={SessionId} Email={Email}",
+					nameof(WebhookConfig), session.Id, session.CustomerEmail);
+
+				var (amountError, amount) = ValidateAmount(session);
+				if (!string.IsNullOrEmpty(amountError))
+				{
+					Logger.LogError("{Method}, Validation failed: {ErrorMessage}", nameof(WebhookConfig), amountError);
+					return Results.BadRequest(amountError.Trim());
+				}
+
+				var (registrationIdError, registrationId) = ValidateRegistrationId(session);
+				if (!string.IsNullOrEmpty(registrationIdError))
+				{
+					Logger.LogError("{Method}, Validation failed: {ErrorMessage} SessionId={SessionId}",
+						nameof(WebhookConfig), registrationIdError, session.Id);
+					return Results.BadRequest(registrationIdError.Trim());
+				}
+
+				var (insertError, newId, alreadyExists) = await InsertDonation(db, Logger, session, amount, registrationId);
+				if (alreadyExists)
+				{
+					// Idempotent: payment already recorded — tell Stripe success so it stops retrying.
+					Logger.LogInformation("{Method}, Donation already present for RegistrationId={RegistrationId}; treating as success",
+						nameof(WebhookConfig), registrationId);
+					return Results.Ok();
+				}
+
+				if (!string.IsNullOrEmpty(insertError))
+				{
+					Logger.LogError("{Method}, DB Insertion failed: {ErrorMessage}", nameof(WebhookConfig), insertError);
+					return Results.BadRequest(insertError.Trim());
+				}
+
+				Logger.LogInformation("{Method}, Donation inserted NewId={NewId} RegistrationId={RegistrationId}",
+					nameof(WebhookConfig), newId, registrationId);
 				return Results.Ok();
 			}
 			catch (StripeException ex)
 			{
-				Logger!.LogError(ex, "{Method}, {Message}", nameof(WebhookConfig), "Stripe error: {ex.Message}");
+				Logger.LogError(ex, "{Method}, Stripe signature/event error: {Message}", nameof(WebhookConfig), ex.Message);
 				return Results.BadRequest();
 			}
 			catch (Exception ex)
 			{
-				Logger!.LogError(ex, "{Method}, {Message}", nameof(WebhookConfig), "Error: {ex.Message}");
+				Logger.LogError(ex, "{Method}, Unhandled webhook error: {Message}", nameof(WebhookConfig), ex.Message);
 				return Results.BadRequest();
 			}
-		});
+		})
+		.AllowAnonymous()
+		.DisableAntiforgery();
 	}
 
-	private static async Task<(string ErrorMsg, int NewId)> InsertDonation(IRepository db, ILogger Logger, Session session, decimal amount, int registrationId)
+	private static async Task<(string ErrorMsg, int NewId, bool AlreadyExists)> InsertDonation(
+		IRepository db,
+		ILogger Logger,
+		Session session,
+		decimal amount,
+		int registrationId)
 	{
 		DonationRecord donation = new()
 		{
 			RegistrationId = registrationId,
 			Amount = amount,
 			Notes = "Stripe Checkout Session Completed",
-			Email = session.CustomerEmail,
+			Email = session.CustomerEmail ?? string.Empty,
 			ReferenceId = session.Id,
-			CreatedBy = $"Endpoint: {StripeConstants.EventType}",
+			CreatedBy = DonationCreatedBy,
 			CreateDate = DateTime.UtcNow
 		};
 
 		var (newId, errorMsg) = await db.DonationInsert(donation);
 
-		if (!string.IsNullOrEmpty(errorMsg)) 
-		{ 
-			Logger.LogWarning("{Method}, {Message}", nameof(WebhookConfig), $"Error message from {nameof(db.DonationInsert)}: {errorMsg}");
-		}
-		else
+		if (!string.IsNullOrEmpty(errorMsg))
 		{
-			Logger.LogInformation("{Method}, {Message}", nameof(WebhookConfig), $"Returned id: {newId}, Email: {session.CustomerEmail}");
+			bool alreadyExists = errorMsg.Contains("already exists", StringComparison.OrdinalIgnoreCase);
+			Logger.LogWarning("{Method}, {Message}", nameof(InsertDonation),
+				$"Error message from {nameof(db.DonationInsert)}: {errorMsg}");
+			return (errorMsg, newId, alreadyExists);
 		}
 
-		return (errorMsg ?? "", newId);
+		Logger.LogInformation("{Method}, Returned id: {NewId}, Email: {Email}",
+			nameof(InsertDonation), newId, session.CustomerEmail);
+		return (string.Empty, newId, false);
 	}
 
 	private static (string ReturnMsg, decimal amount) ValidateAmount(Session session)
@@ -110,14 +159,9 @@ public static class Webhook
 		if (session.AmountTotal.HasValue)
 		{
 			amount = session.AmountTotal.Value / 100m;
-			if (amount == RegistrationFeeEnums.Single.Fee || amount == RegistrationFeeEnums.Family.Fee)
+			if (amount != RegistrationFeeEnums.Single.Fee && amount != RegistrationFeeEnums.Family.Fee)
 			{
-				//returnMsg = "amount is valid";
-			}
-			else
-			{
-				//returnMsg = $"amount is invalid: {session.AmountTotal.Value}";
-				returnMsg = $"amount is invalid: {amount}";
+				returnMsg = $"amount is invalid: {amount} (expected {RegistrationFeeEnums.Single.Fee} or {RegistrationFeeEnums.Family.Fee})";
 			}
 		}
 		else
@@ -132,31 +176,9 @@ public static class Webhook
 		var str = session.Metadata?[RegistrationId];
 		_ = int.TryParse(str, out int registrationId);
 
-		string returnMsg = registrationId > 0 ? "" : "RegistrationId NOT FOUND";
+		string returnMsg = registrationId > 0
+			? string.Empty
+			: $"RegistrationId NOT FOUND in session metadata (raw='{str ?? "(null)"}')";
 		return (returnMsg, registrationId);
 	}
-
-	// ToDo: once I get this working, I need to remove it.
-	private static void LogSecret(string webhookUrl, IConfiguration config, ILogger Logger)
-	{
-		string? secret = config[StripeConstants.WebhookSecret] ?? string.Empty;
-		if (!string.IsNullOrEmpty(secret))
-		{
-			if (secret.Length >= 10)
-			{
-				secret = $"Length >=10; secret.Substring(0, 10)Value: {secret.Substring(0, 10)}";  // secret.Substring(0, 10);
-			}
-			else
-			{
-				secret = $"Length less than 10; secret: {secret}";
-			}
-		}
-		else
-		{
-			secret = "IsNullOrEmpty";
-		}
-		Logger.LogWarning("{Method}, {Message}, {Secret}", nameof(WebhookConfig), webhookUrl, secret);
-	}
-
 }
-

--- a/Sukkot/Helpers/StartupHelper.cs
+++ b/Sukkot/Helpers/StartupHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Serilog;
+using Sukkot.Endpoints.Constants;
 
 namespace Sukkot.Helpers;
 
@@ -13,4 +14,44 @@ public static class StartupHelper
 			Log.Debug("...: {Key} / {Value}", kvp.Key, kvp.Value);
 		}
 	}
+
+	/// <summary>
+	/// Fails fast when Stripe secrets are missing or still the committed appsettings placeholders.
+	/// Does not log secret values.
+	/// </summary>
+	public static void EnsureStripeSecretsConfigured(IConfiguration configuration)
+	{
+		var apiKey = configuration[StripeConstants.ApiKey];
+		if (IsMissingOrPlaceholder(apiKey, StripeConstants.PlaceholderApiKey))
+		{
+			const string message =
+				"Stripe:ApiKey is missing or still the appsettings placeholder. " +
+				"Set a real key via user-secrets, environment variables, or Azure App Settings " +
+				"(see docs/Sukkot-Stripe-Endpoints.md and SECRETS-QUICK-REF.md). " +
+				"Never commit live keys.";
+			Log.Fatal("{Class}, {Method}, {Message}", nameof(StartupHelper), nameof(EnsureStripeSecretsConfigured), message);
+			throw new InvalidOperationException(message);
+		}
+
+		var webhookSecret = configuration[StripeConstants.WebhookSecret];
+		if (IsMissingOrPlaceholder(webhookSecret, StripeConstants.PlaceholderWebhookSecret))
+		{
+			const string message =
+				"Stripe:WebhookSecret is missing or still the appsettings placeholder. " +
+				"Set the webhook signing secret (Stripe CLI whsec_… for local, Dashboard secret for deployed). " +
+				"Endpoint URL must be https://sukkot.livingmessiah.com/webhook/stripesukkotdonation. " +
+				"See docs/Sukkot-Stripe-Endpoints.md.";
+			Log.Fatal("{Class}, {Method}, {Message}", nameof(StartupHelper), nameof(EnsureStripeSecretsConfigured), message);
+			throw new InvalidOperationException(message);
+		}
+
+		Log.Information("{Class}, {Method}, Stripe secrets are present (values not logged)",
+			nameof(StartupHelper), nameof(EnsureStripeSecretsConfigured));
+	}
+
+	private static bool IsMissingOrPlaceholder(string? value, string placeholder) =>
+		string.IsNullOrWhiteSpace(value)
+		|| string.Equals(value.Trim(), placeholder, StringComparison.Ordinal)
+		|| value.Contains("your_stripe", StringComparison.OrdinalIgnoreCase)
+		|| value.TrimEnd().EndsWith("...", StringComparison.Ordinal);
 }

--- a/Sukkot/Program.cs
+++ b/Sukkot/Program.cs
@@ -32,6 +32,7 @@ using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using Sukkot.Endpoints.Data;
+using Sukkot.Helpers;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
@@ -116,8 +117,9 @@ try
 
 	builder.Services.AddLifeCyclePhaseSetting(configuration);
 
-	var stripeApiKey = builder.Configuration[StripeConstants.ApiKey];
-	StripeConfiguration.ApiKey = stripeApiKey;
+	// Fail fast if Stripe keys are missing or still appsettings placeholders (do not log secret values).
+	StartupHelper.EnsureStripeSecretsConfigured(builder.Configuration);
+	StripeConfiguration.ApiKey = builder.Configuration[StripeConstants.ApiKey];
 
 	var app = builder.Build();
 

--- a/docs/Sukkot-Stripe-Endpoints.md
+++ b/docs/Sukkot-Stripe-Endpoints.md
@@ -15,7 +15,7 @@ Sukkot POST /api/stripe/create-session     ← CheckoutSession
 Stripe Checkout (hosted)
     │  card payment
     ▼
-Stripe → POST /webhook/stripesukkotdonation  ← Webhook
+Stripe → POST https://sukkot.livingmessiah.com/webhook/stripesukkotdonation  ← Webhook
     │  signature verify + checkout.session.completed
     │  dbo.stpDonationInsert → dbo.Donation
     │  Registration.StatusId → Complete; delete dbo.Stripe row
@@ -25,8 +25,10 @@ SukkotRegistration database
 Admin GET /health/sukkot/stripe
     │  StripeWebhookHealthCheck
     ▼
-HTTP POST https://livingmessiah.com/webhook/stripesukkotdonation
+HTTP POST https://sukkot.livingmessiah.com/webhook/stripesukkotdonation
 ```
+
+> **Host matters:** the webhook lives on the **Sukkot** App Service (`sukkot.livingmessiah.com`), not the public PWA (`livingmessiah.com`). Stripe Dashboard → Developers → Webhooks must use the Sukkot origin or events never reach `stpDonationInsert`.
 
 | Piece | Project | Role |
 |-------|---------|------|
@@ -64,7 +66,7 @@ Placeholder values appear in `Sukkot/appsettings.json`. Real keys come from user
 | Config / constant | Value | Notes |
 |-------------------|-------|-------|
 | `Stripe` section → `Admin.HealthChecks.Sukkot.Settings.Stripe` | `ApiKey`, `WebhookSecret` | Bound in Admin `Program.cs`; **currently unused** by the health check implementation |
-| `StripeConstants.WebhookUrl` | `https://livingmessiah.com/webhook/stripesukkotdonation` | Hard-coded production probe target |
+| `StripeConstants.WebhookUrl` | `https://sukkot.livingmessiah.com/webhook/stripesukkotdonation` | Hard-coded production probe target (Sukkot host) |
 | `StripeConstants.HealthCheckUrl` | `/health/sukkot/stripe` | Mapped health endpoint on Admin |
 | `StripeConstants.HealthCheckName` | `Is Stripe Webhook Enabled` | Name registered with `AddHealthChecks` |
 
@@ -154,7 +156,7 @@ Insert payload (`DonationRecord`):
 | `Notes` | `"Stripe Checkout Session Completed"` |
 | `Email` | `session.CustomerEmail` |
 | `ReferenceId` | `session.Id` (Stripe Checkout Session id) |
-| `CreatedBy` | `"Endpoint: checkout.session.completed"` |
+| `CreatedBy` | `"Stripe Webhook"` (fits `nvarchar(25)`) |
 | `CreateDate` | `DateTime.UtcNow` |
 
 On signature or processing failure → `400 Bad Request` (Stripe may retry). On success → `200 OK`.
@@ -238,7 +240,7 @@ Admin/HealthChecks/Sukkot/
 `StripeWebhookHealthCheck.CheckHealthAsync`:
 
 1. Builds `HttpClient` from `IHttpClientFactory`.
-2. `POST` body `{}` as `application/json` to the **hard-coded** production webhook URL (`https://livingmessiah.com/webhook/stripesukkotdonation`).
+2. `POST` body `{}` as `application/json` to the **hard-coded** production webhook URL (`https://sukkot.livingmessiah.com/webhook/stripesukkotdonation`).
 3. Does **not** send a valid `Stripe-Signature` header.
 4. Interprets **any success status code** as Healthy; non-success or exception as Unhealthy.
 
@@ -275,15 +277,21 @@ So this check is closer to a **reachability / deployment smoke** of the public w
 
 ## Local development tips
 
+**Full local webhook runbook (CLI login → listen → whsec → pay → verify):**  
+[`Sukkot-Stripe-Webhook-Local-Test.md`](Sukkot-Stripe-Webhook-Local-Test.md)
+
 1. **Domain:** set `EndpointsSetting:Domain` to the Sukkot HTTPS origin so success/cancel redirects work.
 2. **API key:** test mode `sk_test_…` via secrets.
 3. **Webhooks:** use [Stripe CLI](https://stripe.com/docs/stripe-cli) to forward events:
    ```bash
    stripe listen --forward-to https://localhost:<port>/webhook/stripesukkotdonation
    ```
-   Put the CLI `whsec_…` into `Stripe:WebhookSecret`.
-4. **Do not** enable `LogSecret` in `Webhook.cs` in production (debug helper; currently commented at call site).
+   Put the CLI `whsec_…` into `Stripe:WebhookSecret` (local only — not the Azure Dashboard secret).
+4. **Production Stripe Dashboard:** endpoint URL must be  
+   `https://sukkot.livingmessiah.com/webhook/stripesukkotdonation`  
+   Events: at least `checkout.session.completed`. Signing secret → Azure App Setting `Stripe__WebhookSecret` (or `Stripe:WebhookSecret`).
 5. **Fees:** webhook rejects amounts that are not exactly Single or Family fees from `RegistrationFee`.
+6. Startup **fails fast** if `Stripe:ApiKey` / `Stripe:WebhookSecret` are missing or still the committed placeholders.
 
 ---
 
@@ -294,15 +302,17 @@ So this check is closer to a **reachability / deployment smoke** of the public w
 | Create-session validation | Bad form fields | `400` with message |
 | `stpStripeMerge` | DB error | Logged; checkout still attempted |
 | Stripe session create | API / network | Logged; `400` |
+| Webhook never delivered | Wrong host (e.g. livingmessiah.com instead of sukkot.…) | No app logs; Stripe Dashboard shows delivery failures |
 | Webhook signature | Bad secret / body | `StripeException` → `400` |
 | Amount / registration metadata | Invalid | `400`; no insert |
-| Donation already exists | App guard | `400` with error string |
+| Donation already exists | App guard | **`200 OK`** (idempotent; stops Stripe retries) |
 | `stpDonationInsert` FK / error | `NewId` null | Error string; check `dbo.ErrorLog` |
 
 ---
 
 ## Related issues & code
 
+- Issue **#224** — webhook not inserting donations (wrong host / hardening)
 - Issue **#212** — this documentation
 - Issue **#210** — form action must match mapped create-session route (`DonationConstants.BaseSessionUrl`)
 - SQL project: `Database/SukkotRegistration/`

--- a/docs/Sukkot-Stripe-Webhook-Local-Test.md
+++ b/docs/Sukkot-Stripe-Webhook-Local-Test.md
@@ -1,0 +1,204 @@
+# Sukkot Stripe webhook — local test runbook
+
+How to prove end-to-end that a test card payment inserts `dbo.Donation` on a **local** Sukkot app.
+
+Architecture and production URLs: [`Sukkot-Stripe-Endpoints.md`](Sukkot-Stripe-Endpoints.md).
+
+---
+
+## Why this is multi-step
+
+| Piece | Role |
+|-------|------|
+| **Sukkot app** | Creates Checkout sessions; receives webhook POSTs |
+| **Stripe hosted Checkout** | Takes the test card; does **not** call `localhost` by itself |
+| **Stripe CLI** (`stripe listen`) | Forwards Stripe events to `https://localhost:7201/...` |
+| **`whsec_…` from the CLI** | Signing secret for **this** listen session only — must match Sukkot’s `Stripe:WebhookSecret` |
+
+Stripe’s servers never reach your machine. Without `stripe listen`, you get `dbo.Stripe` (create-session) but **no** `dbo.Donation` (webhook).
+
+**Secrets are not shared with Azure:**
+
+| Secret | Where | Used for |
+|--------|--------|----------|
+| CLI `whsec_…` | Local user-secrets only | Verifying events forwarded by `stripe listen` |
+| Dashboard endpoint `whsec_…` | Azure `Stripe__WebhookSecret` | Verifying events POSTed to `sukkot.livingmessiah.com` |
+| `sk_test_…` | Local secrets / Azure | Creating Checkout sessions (API key) |
+
+Do **not** put the local CLI `whsec_` into Azure, and do not expect the Azure secret to work with `stripe listen`.
+
+---
+
+## Prerequisites
+
+- [Stripe CLI](https://stripe.com/docs/stripe-cli) installed
+- Stripe **test mode** account access
+- Sukkot runs on HTTPS **https://localhost:7201** (see `Sukkot/Properties/launchSettings.json`)
+- Local secrets have a valid test API key, e.g. `Stripe:ApiKey` = `sk_test_…` (Checkout uses this; the CLI uses its own login)
+- Seq (or console logs) available if you want log verification
+
+---
+
+## Runbook (successful path)
+
+Keep **two terminals** open: one for Stripe CLI, one for Aspire/Sukkot (or use the IDE for the app).
+
+### 1. Log in the Stripe CLI
+
+```powershell
+stripe login
+```
+
+- CLI prints a **pairing code** and a URL.
+- Open the link in a browser, confirm the code, authorize.
+- If you see `api_key_expired` / 401, run `stripe logout` then `stripe login` again.  
+  The CLI does **not** read Sukkot’s `secrets.json`; expired CLI auth is separate from app secrets.
+
+### 2. Forward webhooks to local Sukkot
+
+```powershell
+stripe listen --forward-to https://localhost:7201/webhook/stripesukkotdonation
+```
+
+Leave this running. When ready you should see something like:
+
+```text
+Ready! You are using Stripe API Version [...]. Your webhook signing secret is whsec_...
+```
+
+### 3. Put that `whsec_` into Sukkot local secrets
+
+Copy the **full** `whsec_…` from the listen output (same terminal session).
+
+**Preferred (CLI):**
+
+```powershell
+cd C:\Source\repos\LivingMessiah\Sukkot
+dotnet user-secrets set "Stripe:WebhookSecret" "whsec_paste_exactly_from_listen"
+```
+
+**Or** edit the user-secrets `secrets.json` for the Sukkot project and set:
+
+```json
+"Stripe:WebhookSecret": "whsec_..."
+```
+
+If you stop and restart `stripe listen`, you may get a **new** `whsec_`. Update secrets again and restart the app.
+
+### 4. Reset DB rows for the email under test
+
+In **SukkotRegistration**, for the test participant email (example):
+
+```sql
+-- Inspect first
+SELECT * FROM dbo.Stripe WHERE Email = N'you@example.com';
+SELECT d.*
+FROM dbo.Donation d
+INNER JOIN dbo.Registration r ON r.Id = d.RegistrationId
+WHERE r.EMail = N'you@example.com';  -- column name as in your schema
+
+-- Then delete (order: donations that block re-test; Stripe is in-flight audit)
+-- Adjust joins/filters to your email / RegistrationId
+DELETE d
+FROM dbo.Donation d
+INNER JOIN dbo.Registration r ON r.Id = d.RegistrationId
+WHERE r.EMail = N'you@example.com';
+
+DELETE FROM dbo.Stripe WHERE Email = N'you@example.com';
+```
+
+Also ensure the registration is still in a state that can open payment (if StatusId is already Complete from a prior test, set it back as needed for your scenario).
+
+Why: the app refuses a second donation for the same registration (`Donation already exists…`), and leftover `dbo.Stripe` rows confuse “in-flight vs paid” checks.
+
+### 5. Launch the app and sign in
+
+1. Start **Aspire** (or run Sukkot alone) so Sukkot is on **https://localhost:7201**.
+2. **Restart Sukkot after any `WebhookSecret` change** (secrets load at startup).
+3. Log in to the Sukkot app (Auth0) as the test user.
+4. Reach the payment step for that registration.
+
+### 6. Pay with Stripe test card
+
+1. Click the Stripe / pay button (posts to `/api/stripe/create-session`).
+2. On Stripe Checkout, use a [test card](https://docs.stripe.com/testing#cards), e.g.:
+   - Number: `4242 4242 4242 4242`
+   - Any future expiry, any CVC, any postal code
+3. Complete payment. Browser should return to **PaymentConfirm** / registration complete UI.
+
+### 7. Verification checklist
+
+All of these should pass:
+
+| # | Check | Expected |
+|---|--------|----------|
+| 1 | **UI** | Registration **Complete** (paid / finished step) |
+| 2 | **`stripe listen` terminal** | `checkout.session.completed` with **`[200]`** on `POST …/webhook/stripesukkotdonation` |
+| 3 | **Database** | Row in **`dbo.Donation`** for that registration; **no** row left in **`dbo.Stripe`** for that email (sproc deletes Stripe after successful insert) |
+| 4 | **Seq** (or app logs) | Events for webhook handling / **`DonationInsert`** / “Donation inserted” |
+
+Other events (`charge.succeeded`, `payment_intent.succeeded`) may appear; after a correct secret they should also return **200** (handler ignores non-`checkout.session.completed`). The donation write is only on **`checkout.session.completed`**.
+
+---
+
+## What “success” looks like in the CLI
+
+```text
+--> checkout.session.completed [evt_...]
+<-- [200] POST https://localhost:7201/webhook/stripesukkotdonation [evt_...]
+```
+
+If you see **`[400]`** on every event (including `charge.succeeded`):
+
+1. `Stripe:WebhookSecret` does not match this listen session’s `whsec_`.
+2. Re-copy `whsec_`, set user-secrets, **restart Sukkot**, pay again.
+
+---
+
+## Common failures
+
+| Symptom | Likely cause |
+|---------|----------------|
+| `dbo.Stripe` yes, `dbo.Donation` no; no webhook lines in Seq | `stripe listen` not running, or wrong port/path |
+| CLI: `Authorization failed` / `api_key_expired` | CLI login expired → `stripe logout` then `stripe login` (not necessarily app secrets) |
+| CLI: all events `[400]` | Wrong/stale `whsec_` in secrets, or app not restarted |
+| Seq: signature / Stripe error | Same as above |
+| Seq: `Donation already exists` | Prior donation for that `RegistrationId` — delete test donation rows |
+| Seq: `RegistrationId NOT FOUND` | Session metadata missing; check create-session path |
+| Seq: `amount is invalid` | Amount not exactly Single/Family fee from `RegistrationFee` |
+| UI complete but DB incomplete | Rare race; re-check webhook 200 and Seq for insert errors |
+
+---
+
+## Optional commands
+
+Trigger a generic event (proves endpoint + secret only; may not insert a real registration donation):
+
+```powershell
+stripe trigger checkout.session.completed
+```
+
+Prefer a real Checkout payment for full metadata (`registrationId`, fee amount).
+
+Update CLI if prompted:
+
+```text
+A newer version of the Stripe CLI is available...
+```
+
+---
+
+## Production reminder (not this runbook)
+
+- Webhook URL: `https://sukkot.livingmessiah.com/webhook/stripesukkotdonation` (Sukkot host, **not** livingmessiah.com PWA).
+- Azure `Stripe__WebhookSecret` = Dashboard signing secret for that endpoint.
+- Local CLI `whsec_` stays on the machine only.
+
+---
+
+## Related
+
+- Issue **#224** — webhook not writing donations
+- [`Sukkot-Stripe-Endpoints.md`](Sukkot-Stripe-Endpoints.md) — full create-session / webhook / DB map
+- `Sukkot/Endpoints/Webhook.cs` — handler
+- `DonationConstants.WebHookUrl` → `/webhook/stripesukkotdonation`


### PR DESCRIPTION
## Summary
- Point Admin health check and docs at `https://sukkot.livingmessiah.com/webhook/stripesukkotdonation` (not the PWA host).
- Harden the Sukkot webhook: AllowAnonymous, DisableAntiforgery, clearer logging, CreatedBy length, idempotent already-exists → 200.
- Fail fast when Stripe API key / webhook secret are missing or still appsettings placeholders.
- Add local Stripe CLI webhook test runbook (`docs/Sukkot-Stripe-Webhook-Local-Test.md`).

## Test plan
- [x] Local: `stripe login` → `stripe listen` → set CLI `whsec_` in user-secrets → restart Sukkot → test card payment
- [x] CLI shows `checkout.session.completed` with HTTP 200
- [x] UI reaches Registration Complete
- [x] `dbo.Donation` row present; `dbo.Stripe` cleared for that email
- [ ] Production: confirm Stripe Dashboard webhook URL is sukkot host and Azure `Stripe__WebhookSecret` is the Dashboard secret (not CLI whsec)
- [ ] After merge/deploy: Admin `/health/sukkot/stripe` probes the Sukkot host

Fixes #224