### PR TITLE
Implement Admin DeleteRegistration and DeleteHRA

### DIFF
--- a/Admin/Features/Sukkot/Home/Data/Repository.cs
+++ b/Admin/Features/Sukkot/Home/Data/Repository.cs
@@ -16,9 +16,11 @@ public interface IRepository
 	Task<VM> Get(int id);
 
 	Task<Tuple<int, int, string>> InsertHouseRulesAgreement(string email, string timeZone);  // FN:1
+	Task<int> DeleteHRA(int id);
 	Task<Tuple<int, int, string>> CreateRegistration(DTO formVM);
 	Task<Tuple<int, int, string>> UpdateRegistration(DTO formVM);
-	
+	Task<Tuple<int, int, string>> DeleteRegistration(int id);
+
 	Task<RegistrationQuery> ById(int id);
 }
 
@@ -81,6 +83,18 @@ public class Repository : BaseRepositoryAsync, IRepository
 
 			return new Tuple<int, int, string>(NewId, SprocReturnValue, ReturnMsg);
 
+		});
+	}
+
+	public async Task<int> DeleteHRA(int id)
+	{
+		Sql = "dbo.stpHRADelete";
+		Parms = new DynamicParameters(new { Id = id });
+		return await WithConnectionAsync(async connection =>
+		{
+			Logger!.LogDebug("{Method} {Id}, {Sql}", nameof(DeleteHRA), id, Sql);
+			var affectedRows = await connection.ExecuteAsync(sql: Sql, param: Parms, commandType: CommandType.StoredProcedure);
+			return affectedRows;
 		});
 	}
 	#endregion
@@ -252,6 +266,45 @@ WHERE Id = @Id";
 			else
 			{
 				ReturnMsg = $"Registration updated for {formVM.FamilyName}/{formVM.EMail}";
+			}
+
+			return new Tuple<int, int, string>(RowsAffected, SprocReturnValue, ReturnMsg);
+		});
+	}
+
+	public async Task<Tuple<int, int, string>> DeleteRegistration(int id)
+	{
+		Sql = "dbo.stpRegistrationDelete";
+		Parms = new DynamicParameters(new { RegistrationId = id });
+
+		Parms.Add("@ReturnValue", dbType: DbType.Int32, direction: ParameterDirection.ReturnValue);
+
+		int RowsAffected = 0;
+		int SprocReturnValue = 0;
+		string ReturnMsg = "";
+
+		return await WithConnectionAsync(async connection =>
+		{
+			Logger!.LogDebug("{Method} {id}, {Sql} ", nameof(DeleteRegistration), id, Sql);
+			RowsAffected = await connection.ExecuteAsync(sql: Sql, param: Parms, commandType: CommandType.StoredProcedure);
+			SprocReturnValue = Parms.Get<int>("ReturnValue");
+
+			if (SprocReturnValue != 0) // ReturnValueOk
+			{
+				if (SprocReturnValue == 51000) // Can not have donation rows when deleting registration
+				{
+					ReturnMsg = $"Database call did not delete the registration record because it has donation rows; RegistrationId: {id}; Manually delete the donation row(s) then delete the registration.";
+					Logger!.LogWarning("{Method} {ReturnMsg}", nameof(DeleteRegistration), ReturnMsg);
+				}
+				else
+				{
+					ReturnMsg = $"Database call failed to delete RegistrationId: {id}; SprocReturnValue: {SprocReturnValue}";
+					Logger!.LogError("{Method} {ReturnMsg}", nameof(DeleteRegistration), ReturnMsg);
+				}
+			}
+			else
+			{
+				ReturnMsg = $"Registration deleted for RegistrationId: {id}";
 			}
 
 			return new Tuple<int, int, string>(RowsAffected, SprocReturnValue, ReturnMsg);

--- a/Admin/Features/Sukkot/Home/Index.razor
+++ b/Admin/Features/Sukkot/Home/Index.razor
@@ -29,11 +29,11 @@
 
       <LoadingComponent IsLoading="RegistrationList == null" TurnSpinnerOff=TurnSpinnerOff>
         <div class="@MediaQuery.XsOrSm.DivClass">
-          <XsSmCard RegistrationList="RegistrationList"
+          <XsSmCard @key="refreshKey" RegistrationList="RegistrationList"
                     OnCrudActionSelected="ReturnedCrudActionSelected" />
         </div>
         <div class="@MediaQuery.MdOrLgOrXl.DivClass">
-          <MdLgXlTable RegistrationList="RegistrationList"
+          <MdLgXlTable @key="refreshKey" RegistrationList="RegistrationList"
                        OnCrudActionSelected="ReturnedCrudActionSelected" />
         </div>
 
@@ -88,6 +88,14 @@
         }
       }
     }
+
+    @if (showDeleteModal && pendingDelete is not null)
+    {
+      <DeleteModal Id="@Id"
+                   Title="@deleteModalTitle"
+                   Message="@deleteModalMessage"
+                   OnDeleteResponse="ReturnedDeleteResponse" />
+    }
   </Authorized>
   <NotAuthorized>
     <LoginRedirectCard Nav="Nav.Sukkot" ReturnUrl=@Nav.Sukkot.Index />
@@ -104,35 +112,43 @@
   protected Enums.VisibleComponent? VisibleComponent { get; set; } = Enums.VisibleComponent.RegistrationList;
 
   bool TurnSpinnerOff = false;
+  private Guid refreshKey = Guid.NewGuid();
+  private bool showDeleteModal = false;
+  private Crud? pendingDelete;
+  private string deleteModalTitle = string.Empty;
+  private string deleteModalMessage = string.Empty;
 
   protected List<Data.RegistrationListQuery>? RegistrationList;
 
 
   int Id { get; set; } = 0;
   string? Email { get; set; } = null;
+  string? FullName { get; set; } = null;
   DetailPageHeaderVM? DetailPageHeaderVM;
 
   protected override async Task OnInitializedAsync()
   {
     Logger!.LogDebug("{Method}", nameof(OnInitializedAsync));
+    await LoadRegistrationList();
+    TurnSpinnerOff = true;
+  }
 
+  private async Task LoadRegistrationList()
+  {
     try
     {
       RegistrationList = await db!.GetAll();
       if (RegistrationList is null)
       {
-        Logger!.LogWarning("{Method} {Message}", nameof(OnInitializedAsync), "RegistrationList is null");
+        Logger!.LogWarning("{Method} {Message}", nameof(LoadRegistrationList), "RegistrationList is null");
         Toast!.ShowWarning($"RegistrationList is null");
       }
-
     }
     catch (Exception ex)
     {
-      Logger!.LogError(ex, "{Method}", nameof(OnInitializedAsync));
-      Toast!.ShowError($"An invalid operation occurred, contact your administrator | {nameof(OnInitializedAsync)}");
+      Logger!.LogError(ex, "{Method}", nameof(LoadRegistrationList));
+      Toast!.ShowError($"An invalid operation occurred, contact your administrator | {nameof(LoadRegistrationList)}");
     }
-
-    TurnSpinnerOff = true;
   }
 
 
@@ -155,40 +171,121 @@
       VisibleComponent = Enums.VisibleComponent.RegistrationDetail;
       DetailPageHeaderVM = new DetailPageHeaderVM(args.Crud.Name, args.FullName);
     }
+    else if (args.Crud == Crud.AddRegistration)
+    {
+      Id = 0;
+      Email = args.EMail;
+      VisibleComponent = Enums.VisibleComponent.Registrant;
+      DetailPageHeaderVM = new DetailPageHeaderVM(args.Crud.Name, args.FullName);
+    }
+    else if (args.Crud == Crud.Edit)
+    {
+      Id = args.Id;
+      Email = args.EMail;
+      VisibleComponent = Enums.VisibleComponent.Registrant;
+      DetailPageHeaderVM = new DetailPageHeaderVM(args.Crud.Name, args.FullName);
+    }
+    else if (args.Crud == Crud.Donation)
+    {
+      Id = args.Id;
+      VisibleComponent = Enums.VisibleComponent.Donation;
+      DetailPageHeaderVM = new DetailPageHeaderVM(args.Crud.Name, args.FullName);
+    }
+    else if (args.Crud == Crud.DeleteRegistration)
+    {
+      Id = args.Id;
+      FullName = args.FullName;
+      pendingDelete = Crud.DeleteRegistration;
+      deleteModalTitle = "Delete Registration";
+      deleteModalMessage = $"Registration for Name: {args.FullName}";
+      showDeleteModal = true;
+    }
+    else if (args.Crud == Crud.DeleteHRA)
+    {
+      Id = args.Id; // IdHra from ActionButtonGroup
+      Email = args.EMail;
+      pendingDelete = Crud.DeleteHRA;
+      deleteModalTitle = "Delete HRA";
+      deleteModalMessage = $"HRA for e-mail: {args.EMail}";
+      showDeleteModal = true;
+    }
     else
     {
-      if (args.Crud == Crud.AddRegistration)
-      {
-        Id = 0;
-        Email = args.EMail;
-        VisibleComponent = Enums.VisibleComponent.Registrant;
-        DetailPageHeaderVM = new DetailPageHeaderVM(args.Crud.Name, args.FullName);
-      }
-      else
-      {
-        if (args.Crud == Crud.Edit)
-        {
-          Id = args.Id;
-          Email = args.EMail;
-          VisibleComponent = Enums.VisibleComponent.Registrant;
-          DetailPageHeaderVM = new DetailPageHeaderVM(args.Crud.Name, args.FullName);
-        }
-        else
-        {
-          if (args.Crud == Crud.Donation)
-          {
-            Id = args.Id;
-            VisibleComponent = Enums.VisibleComponent.Donation;
-            DetailPageHeaderVM = new DetailPageHeaderVM(args.Crud.Name, args.FullName);
-          }
-          else
-          {
-            Toast!.ShowWarning($"Unknown Crud Action: {args.Crud.Name}");
-            //  if (args.Crud == Crud.DeleteRegistration) { }
-          }
-        }
-      } 
-
+      Toast!.ShowWarning($"Unknown Crud Action: {args.Crud.Name}");
     }
+  }
+
+  private async Task ReturnedDeleteResponse(bool shouldDelete)
+  {
+    showDeleteModal = false;
+    var deleteAction = pendingDelete;
+    pendingDelete = null;
+
+    if (!shouldDelete || deleteAction is null)
+    {
+      return;
+    }
+
+    if (deleteAction == Crud.DeleteRegistration)
+    {
+      await DeleteRegistrationCommand(Id, FullName ?? "EMPTY");
+    }
+    else if (deleteAction == Crud.DeleteHRA)
+    {
+      await DeleteHraCommand(Id, Email ?? "EMPTY");
+    }
+  }
+
+  private async Task DeleteRegistrationCommand(int id, string fullName)
+  {
+    Logger!.LogDebug("{Method} Id: {Id}, FullName: {FullName}", nameof(DeleteRegistrationCommand), id, fullName);
+    try
+    {
+      var (rowsAffected, sprocReturnValue, returnMsg) = await db!.DeleteRegistration(id);
+
+      if (sprocReturnValue == 51000) // Can not have donation rows when deleting registration
+      {
+        Toast!.ShowWarning(returnMsg);
+        return;
+      }
+
+      if (sprocReturnValue != 0)
+      {
+        Toast!.ShowError(returnMsg);
+        return;
+      }
+
+      Toast!.ShowInfo($"Registration deleted for {fullName}");
+      await RefreshRegistrationList();
+    }
+    catch (Exception ex)
+    {
+      Logger!.LogError(ex, "{Method} Id: {Id}", nameof(DeleteRegistrationCommand), id);
+      Toast!.ShowError($"{Global.ToastShowError} | {nameof(DeleteRegistrationCommand)}");
+    }
+  }
+
+  private async Task DeleteHraCommand(int id, string email)
+  {
+    Logger!.LogDebug("{Method} Id: {Id}, Email: {Email}", nameof(DeleteHraCommand), id, email);
+    try
+    {
+      var affectedRows = await db!.DeleteHRA(id);
+      Logger!.LogInformation("{Method} affectedRows: {AffectedRows}", nameof(DeleteHraCommand), affectedRows);
+      Toast!.ShowInfo($"House Rules Agreement deleted for {email}");
+      await RefreshRegistrationList();
+    }
+    catch (Exception ex)
+    {
+      Logger!.LogError(ex, "{Method} Id: {Id}", nameof(DeleteHraCommand), id);
+      Toast!.ShowError($"{Global.ToastShowError} | {nameof(DeleteHraCommand)}");
+    }
+  }
+
+  private async Task RefreshRegistrationList()
+  {
+    await LoadRegistrationList();
+    refreshKey = Guid.NewGuid();
+    VisibleComponent = Enums.VisibleComponent.RegistrationList;
   }
 }

--- a/Admin/Features/Sukkot/Home/RegistrationList/ActionButtonGroup.razor
+++ b/Admin/Features/Sukkot/Home/RegistrationList/ActionButtonGroup.razor
@@ -5,7 +5,6 @@
 @using StepEnums = RCL.Features.Sukkot.Enums.Step;
 
 @inject ILogger<ActionButtonGroup>? Logger
-@inject IToastService? Toast
 
 @* @if (StatusId == RegStatusEnums.Status.StartRegistration.Value) *@
 
@@ -67,11 +66,10 @@ else
 				break;
 
 			case nameof(Crud.DeleteRegistration):
-				Toast!.ShowWarning($"{Crud.DeleteRegistration.Name} is not yet implemented; Inside{nameof(ActionButtonGroup)}");
+				await OnCrudActionSelected.InvokeAsync(args);
 				break;
 
 			case nameof(Crud.DeleteHRA):
-				Toast!.ShowWarning($"{Crud.DeleteHRA.Name} is not yet implemented; Inside{nameof(ActionButtonGroup)}");
 				await OnCrudActionSelected.InvokeAsync(args);
 				break;
 
@@ -84,17 +82,5 @@ else
 				break;
 		}
 	}
-
-	//[CascadingParameter] IModalService Modal { get; set; } = default!;
-
-	/*
-		private async Task<bool> IsModalConfirmed(string title, string label, string value)
-	{
-		var parameters = new ModalParameters { { nameof(ConfirmDeleteModal.Message), $"{title} for {label}: {value}" } };
-		var modal = Modal.Show<ConfirmDeleteModal>("Confirmation Required", parameters);
-		var result = await modal.Result;
-		return result.Confirmed;
-	}
-	 */
 
 }

--- a/Admin/Features/Sukkot/Home/RegistrationList/DeleteModal.razor
+++ b/Admin/Features/Sukkot/Home/RegistrationList/DeleteModal.razor
@@ -1,0 +1,31 @@
+<div class="modal fade show" tabindex="-1" style="display: block;" aria-modal="true" role="dialog">
+	<div class="modal-dialog">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h5 class="modal-title">@Title | Id: @Id</h5>
+				<button type="button" class="btn-close" @onclick="@(() => HandleResponse(false))" aria-label="Close"></button>
+			</div>
+			<div class="modal-body">
+				<p>Click <b class="text-danger">Delete</b> to permanently remove this record.</p>
+				<h5 class="my-3">@Message</h5>
+			</div>
+			<div class="modal-footer">
+				<button type="button" class="btn btn-secondary" @onclick="@(() => HandleResponse(false))">Cancel</button>
+				<button type="button" class="btn btn-danger" @onclick="@(() => HandleResponse(true))">Delete</button>
+			</div>
+		</div>
+	</div>
+</div>
+<div class="modal-backdrop fade show"></div>
+
+@code {
+	[Parameter, EditorRequired] public int Id { get; set; }
+	[Parameter, EditorRequired] public string Title { get; set; } = string.Empty;
+	[Parameter, EditorRequired] public string Message { get; set; } = string.Empty;
+	[Parameter] public EventCallback<bool> OnDeleteResponse { get; set; }
+
+	private async Task HandleResponse(bool okToDelete)
+	{
+		await OnDeleteResponse.InvokeAsync(okToDelete);
+	}
+}


### PR DESCRIPTION
## Summary
- Implement Admin Sukkot **DeleteRegistration** (Fixes #227): confirm modal, `stpRegistrationDelete`, toast handling (including donation block), and list refresh.
- Also implement **DeleteHRA** in the same flow: confirm modal, `stpHRADelete`, toast, and list refresh for start-registration rows.
- Add shared `DeleteModal` and repository methods; remount list views via `@key` after successful deletes.

## Test plan
- [ ] Admin `/Sukkot` loads registration list for authorized user
- [ ] Delete Registration (no donations): confirm → success toast → row removed from list
- [ ] Delete Registration (with donations): button disabled / sproc warning path as expected
- [ ] Cancel on confirm modal does not delete
- [ ] Delete HRA on start-registration row: confirm → success toast → HRA row gone after refresh
- [ ] Footer/list counts look correct after delete
